### PR TITLE
Add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,71 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age,
+body size, disability, ethnicity, gender identity and expression, level of
+experience, nationality, personal appearance, race, religion, or sexual
+identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event. Representation of a
+project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at
+[reason-association.org](https://www.reason-association.org/about#contact). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an
+incident. Further details of specific enforcement policies may be posted
+separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [https://contributor-covenant.org/version/1/4][version]
+
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](code-of-conduct.md)
 
-# reasonml.org 
+# reasonml.org
 
 This is the repository for [reasonml.org](https://reasonml.org) and is currently **work
 in progress**.
@@ -8,7 +8,7 @@ in progress**.
 ## Setup
 
 ```
-yarn 
+yarn
 
 # Initial build
 yarn bs:build
@@ -80,6 +80,7 @@ NODE_ENV=production postcss styles/main.css -o test.css
 Check out our [CONTRIBUTING.md](CONTRIBUTING.md) for how to get started working
 on this project.
 
-**TLDR:** Always make sure to have an issue assigned / create issues, or join
-us in the [ReasonML Discord #docs channel](https://discord.gg/fscQAnj) to find
-a good task to work on.
+**TLDR:** Read and comply to our [Code of Conduct](CODE_OF_CONDUCT.md); always
+make sure to have an issue assigned / create issues / join us in the
+[ReasonML Discord #docs channel](https://discord.gg/fscQAnj) to find a good
+task to work on.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](code-of-conduct.md)
+
 # reasonml.org 
 
 This is the repository for [reasonml.org](https://reasonml.org) and is currently **work


### PR DESCRIPTION
By merging this PR, the initiators of this project hereby pledge that they will take responsibility for establishing and maintaining an inclusive and positive contribution experience to this project, as stated in the committed `CODE_OF_CONDUCT.md` file.

In more detail, this PR adapts the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/) in its original form, since I think it reflects our values and the environment we want to create really well.

Proposals for adaptions are highly welcome, otherwise I would go with the vanilla version for now.



