### PR TITLE
belt-docs: fix all failing examples

### DIFF
--- a/pages/belt_docs/hash-set.mdx
+++ b/pages/belt_docs/hash-set.mdx
@@ -40,9 +40,8 @@ The invariant must be held: for two elements who are equal, their hashed value s
 
 Here the compiler would infer `s0` and `s1` having different type so that it would not mix.
 
-```re example
+```re sig
 let s0: t(int, I0.identity);
-
 let s1: t(int, I1.identity);
 ```
 
@@ -50,67 +49,67 @@ We can add elements to the collection (see last two lines in the example above).
 
 ## t
 
-```
+```re sig
 type t('a, 'id);
 ```
 
 ## id
 
-```
+```re sig
 type id('a, 'id) = BeltId.hashable('a, 'id);
 ```
 
 ## make
 
-```
+```re sig
 let make: (~hintSize: int, ~id: id('a, 'id)) => t('a, 'id);
 ```
 
 ## clear
 
-```
+```re sig
 let clear: t('a, 'id) => unit;
 ```
 
 ## isEmpty
 
-```
+```re sig
 let isEmpty: t('a, 'b) => bool;
 ```
 
 ## add
 
-```
+```re sig
 let add: (t('a, 'id), 'a) => unit;
 ```
 
 ## copy
 
-```
+```re sig
 let copy: t('a, 'id) => t('a, 'id);
 ```
 
 ## has
 
-```
+```re sig
 let has: (t('a, 'id), 'a) => bool;
 ```
 
 ## remove
 
-```
+```re sig
 let remove: (t('a, 'id), 'a) => unit;
 ```
 
 ## forEachU
 
-```
+```re sig
 let forEachU: (t('a, 'id), [@bs] ('a => unit)) => unit;
 ```
 
 ## forEach
 
-```
+```re sig
 let forEach: (t('a, 'id), 'a => unit) => unit;
 ```
 
@@ -118,13 +117,13 @@ Order unspecified.
 
 ## reduceU
 
-```
+```re sig
 let reduceU: (t('a, 'id), 'c, [@bs] (('c, 'a) => 'c)) => 'c;
 ```
 
 ## reduce
 
-```
+```re sig
 let reduce: (t('a, 'id), 'c, ('c, 'a) => 'c) => 'c;
 ```
 
@@ -132,36 +131,36 @@ Order unspecified.
 
 ## size
 
-```
+```re sig
 let size: t('a, 'id) => int;
 ```
 
 ## logStats
 
-```
+```re sig
 let logStats: t('a, 'b) => unit;
 ```
 
 ## toArray
 
-```
+```re sig
 let toArray: t('a, 'id) => array('a);
 ```
 
 ## fromArray
 
-```
+```re sig
 let fromArray: (array('a), ~id: id('a, 'id)) => t('a, 'id);
 ```
 
 ## mergeMany
 
-```
+```re sig
 let mergeMany: (t('a, 'id), array('a)) => unit;
 ```
 
 ## getBucketHistogram
 
-```
+```re sig
 let getBucketHistogram: t('a, 'b) => array(int);
 ```

--- a/pages/belt_docs/map-dict.mdx
+++ b/pages/belt_docs/map-dict.mdx
@@ -85,9 +85,15 @@ let findFirstBy: (t('k, 'v, 'id), ('k, 'v) => bool) => option(('k, 'v));
 `findFirstBy(m, p)` uses function `f` to find the first key value pair to match predicate `p`.
 
 ```re example
-let s0 = fromArray(~id=(module IntCmp), [|(4, "4"), (1, "1"), (2, "2,"(3, ""))|]);
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
 
-findFirstBy(s0, (k, v) => k == 4) == option((4, "4"));
+let s0 = Belt.Map.Dict.fromArray([|(4, "4"), (1, "1"), (2, "2"), (3, "3")|], ~cmp=IntCmp.cmp);
+
+Belt.Map.Dict.findFirstBy(s0, (k, _) => k == 4) == Some((4, "4"));
 ```
 
 ## forEachU

--- a/pages/belt_docs/map-int.mdx
+++ b/pages/belt_docs/map-int.mdx
@@ -83,9 +83,9 @@ let findFirstBy: (t('v), (key, 'v) => bool) => option((key, 'v));
 `findFirstBy(m, p)` uses function `f` to find the first key value pair to match predicate `p`.
 
 ```re example
-let s0 = fromArray(~id=(module IntCmp), [|(4, "4"), (1, "1"), (2, "2,"(3, ""))|]);
+let s0 = Belt.Map.Int.fromArray([|(4, "4"), (1, "1"), (2, "2"), (3, "3")|]);
 
-findFirstBy(s0, (k, v) => k == 4) == option((4, "4"));
+Belt.Map.Int.findFirstBy(s0, (k, v) => k == 4) == Some((4, "4"));
 ```
 
 ## forEachU

--- a/pages/belt_docs/map-string.mdx
+++ b/pages/belt_docs/map-string.mdx
@@ -83,9 +83,9 @@ let findFirstBy: (t('v), (key, 'v) => bool) => option((key, 'v));
 `findFirstBy(m, p)` uses function `f` to find the first key value pair to match predicate `p`.
 
 ```re example
-let s0 = fromArray(~id=(module IntCmp), [|(4, "4"), (1, "1"), (2, "2,"(3, ""))|]);
+let s0 = Belt.Map.String.fromArray([|("4", 4), ("1", 1), ("2", 2), ("3", 3)|]);
 
-findFirstBy(s0, (k, v) => k == 4) == option((4, "4"));
+Belt.Map.String.findFirstBy(s0, (k, _) => k == "4") == Some(("4", 4));
 ```
 
 ## forEachU

--- a/pages/belt_docs/mutable-set-int.mdx
+++ b/pages/belt_docs/mutable-set-int.mdx
@@ -116,12 +116,12 @@ let add: (t, value) => unit;
 Adds element to set. If element existed in set, value is unchanged.
 
 ```re example
-let s0 = Belt.MutableSet.make();
-s0->Belt.MutableSet.add(1);
-s0->Belt.MutableSet.add(2);
-s0->Belt.MutableSet.add(2);
+let s0 = Belt.MutableSet.Int.make();
+s0->Belt.MutableSet.Int.add(1);
+s0->Belt.MutableSet.Int.add(2);
+s0->Belt.MutableSet.Int.add(2);
 
-s0->Belt.MutableSet.toArray; /* [|1, 2|] */
+s0->Belt.MutableSet.Int.toArray; /* [|1, 2|] */
 ```
 
 ## addCheck
@@ -139,10 +139,10 @@ let mergeMany: (t, array(value)) => unit;
 Adds each element of array to set. Unlike [add](#add), the reference of return value might be changed even if all values in array already exist in set
 
 ```re example
-let set = Belt.MutableSet.make();
+let set = Belt.MutableSet.Int.make();
 
-set->Belt.MutableSet.mergeMany([|5, 4, 3, 2, 1|]);
-set->Belt.MutableSet.toArray; /* [|1, 2, 3, 4, 5|] */
+set->Belt.MutableSet.Int.mergeMany([|5, 4, 3, 2, 1|]);
+set->Belt.MutableSet.Int.toArray; /* [|1, 2, 3, 4, 5|] */
 ```
 
 ## remove
@@ -154,12 +154,12 @@ let remove: (t, value) => unit;
 Removes element from set. If element wasn't existed in set, value is unchanged.
 
 ```re example
-let s0 = Belt.MutableSet.fromArray([|2,3,1,4,5|]);
-s0->Belt.MutableSet.remove(1);
-s0->Belt.MutableSet.remove(3);
-s0->Belt.MutableSet.remove(3);
+let s0 = Belt.MutableSet.Int.fromArray([|2,3,1,4,5|]);
+s0->Belt.MutableSet.Int.remove(1);
+s0->Belt.MutableSet.Int.remove(3);
+s0->Belt.MutableSet.Int.remove(3);
 
-s0->Belt.MutableSet.toArray; /* [|2,4,5|] */
+s0->Belt.MutableSet.Int.toArray; /* [|2,4,5|] */
 ```
 
 ## removeCheck
@@ -177,10 +177,10 @@ let removeMany: (t, array(value)) => unit;
 Removes each element of array from set.
 
 ```re example
-let set = Belt.MutableSet.fromArray([1, 2, 3, 4]);
+let set = Belt.MutableSet.Int.fromArray([|1, 2, 3, 4|]);
 
-set->Belt.MutableSet.removeMany([|5, 4, 3, 2, 1|]);
-set->Belt.MutableSet.toArray; /* [||] */
+set->Belt.MutableSet.Int.removeMany([|5, 4, 3, 2, 1|]);
+set->Belt.MutableSet.Int.toArray; /* [||] */
 ```
 
 ## union
@@ -192,10 +192,10 @@ let union: (t, t) => t;
 Returns union of two sets.
 
 ```re example
-let s0 = Belt.MutableSet.fromArray([|5,2,3,5,6|]);
-let s1 = Belt.MutableSet.fromArray([|5,2,3,1,5,4|]);
-let union = Belt.MutableSet.union(s0, s1);
-union->Belt.MutableSet.toArray; /* [|1,2,3,4,5,6|] */
+let s0 = Belt.MutableSet.Int.fromArray([|5,2,3,5,6|]);
+let s1 = Belt.MutableSet.Int.fromArray([|5,2,3,1,5,4|]);
+let union = Belt.MutableSet.Int.union(s0, s1);
+union->Belt.MutableSet.Int.toArray; /* [|1,2,3,4,5,6|] */
 ```
 
 ## intersect
@@ -208,10 +208,10 @@ Returns intersection of two sets.
 
 ```re example
 
-let s0 = Belt.MutableSet.fromArray([|5,2,3,5,6|]);
-let s1 = Belt.MutableSet.fromArray([|5,2,3,1,5,4|]);
-let intersect = Belt.MutableSet.intersect(s0, s1);
-intersect->Belt.MutableSet.toArray; /* [|2,3,5|] */
+let s0 = Belt.MutableSet.Int.fromArray([|5,2,3,5,6|]);
+let s1 = Belt.MutableSet.Int.fromArray([|5,2,3,1,5,4|]);
+let intersect = Belt.MutableSet.Int.intersect(s0, s1);
+intersect->Belt.MutableSet.Int.toArray; /* [|2,3,5|] */
 ```
 
 ## diff
@@ -223,10 +223,10 @@ let diff: (t, t) => t;
 Returns elements from first set, not existing in second set.
 
 ```re example
-let s0 = Belt.MutableSet.fromArray([|5,2,3,5,6|]);
-let s1 = Belt.MutableSet.fromArray([|5,2,3,1,5,4|]);
-Belt.MutableSet.toArray(Belt.MutableSet.diff(s0, s1)); /* [|6|] */
-Belt.MutableSet.toArray(Belt.MutableSet.diff(s1,s0)); /* [|1,4|] */
+let s0 = Belt.MutableSet.Int.fromArray([|5,2,3,5,6|]);
+let s1 = Belt.MutableSet.Int.fromArray([|5,2,3,1,5,4|]);
+Belt.MutableSet.Int.toArray(Belt.MutableSet.Int.diff(s0, s1)); /* [|6|] */
+Belt.MutableSet.Int.toArray(Belt.MutableSet.Int.diff(s1,s0)); /* [|1,4|] */
 ```
 
 ## subset
@@ -238,12 +238,12 @@ let subset: (t, t) => bool;
 Checks if second set is subset of first set.
 
 ```re example
-let s0 = Belt.MutableSet.fromArray([|5,2,3,5,6|]);
-let s1 = Belt.MutableSet.fromArray([|5,2,3,1,5,4|]);
-let s2 = Belt.MutableSet.intersect(s0, s1);
-Belt.MutableSet.subset(s2, s0); /* true */
-Belt.MutableSet.subset(s2, s1); /* true */
-Belt.MutableSet.subset(s1, s0); /* false */
+let s0 = Belt.MutableSet.Int.fromArray([|5,2,3,5,6|]);
+let s1 = Belt.MutableSet.Int.fromArray([|5,2,3,1,5,4|]);
+let s2 = Belt.MutableSet.Int.intersect(s0, s1);
+Belt.MutableSet.Int.subset(s2, s0); /* true */
+Belt.MutableSet.Int.subset(s2, s1); /* true */
+Belt.MutableSet.Int.subset(s1, s0); /* false */
 ```
 
 ## cmp
@@ -263,10 +263,10 @@ let eq: (t, t) => bool;
 Checks if two sets are equal.
 
 ```re example
-let s0 = Belt.MutableSet..fromArray([|5,2,3|]);
-let s1 = Belt.MutableSet.fromArray([|3,2,5|]);
+let s0 = Belt.MutableSet.Int.fromArray([|5,2,3|]);
+let s1 = Belt.MutableSet.Int.fromArray([|3,2,5|]);
 
-Belt.MutableSet.eq(s0, s1); /* true */
+Belt.MutableSet.Int.eq(s0, s1); /* true */
 ```
 
 ## forEachU
@@ -286,10 +286,10 @@ let forEach: (t, value => unit) => unit;
 Applies function `f` in turn to all elements of set in increasing order.
 
 ```re example
-let s0 = Belt.MutableSet.fromArray([|5,2,3,5,6|]);
+let s0 = Belt.MutableSet.Int.fromArray([|5,2,3,5,6|]);
 let acc = ref([]);
-s0->Belt.MutableSet.forEach(x => {
-  acc := acc->Belt.List.add(x)
+s0->Belt.MutableSet.Int.forEach(x => {
+  acc := Belt.List.add(acc^, x)
 });
 acc; /* [6,5,3,2] */
 ```
@@ -309,9 +309,9 @@ let reduce: (t, 'a, ('a, value) => 'a) => 'a;
 Applies function `f` to each element of set in increasing order. Function `f` has two parameters: the item from the set and an “accumulator”, which starts with a value of `initialValue`. `reduce` returns the final value of the accumulator.
 
 ```re example
-let s0 = Belt.MutableSet.fromArray([|5,2,3,5,6|]);
-s0->Belt.MutableSet.reduce([], (element, acc) =>
-  acc->Bs.List.add(element)
+let s0 = Belt.MutableSet.Int.fromArray([|5,2,3,5,6|]);
+s0->Belt.MutableSet.Int.reduce([], (acc, element) =>
+  acc->Belt.List.add(element)
 ); /* [6,5,3,2] */
 ```
 
@@ -332,8 +332,8 @@ Checks if all elements of the set satisfy the predicate. Order unspecified.
 ```re example
 let isEven = x => x mod 2 == 0;
 
-let s0 = Belt.MutableSet.fromArray([|2,4,6,8|]);
-s0->Belt.MutableSet.every(isEven); /* true */
+let s0 = Belt.MutableSet.Int.fromArray([|2,4,6,8|]);
+s0->Belt.MutableSet.Int.every(isEven); /* true */
 ```
 
 ## someU
@@ -353,8 +353,8 @@ Checks if at least one element of the set satisfies the predicate.
 ```re example
 let isOdd = x => x mod 2 != 0;
 
-let s0 = Belt.MutableSet.fromArray([|1,2,4,6,8|]);
-s0->Belt.MutableSet.some(isOdd); /* true */
+let s0 = Belt.MutableSet.Int.fromArray([|1,2,4,6,8|]);
+s0->Belt.MutableSet.Int.some(isOdd); /* true */
 ```
 
 ## keepU
@@ -374,10 +374,10 @@ Returns the set of all elements that satisfy the predicate.
 ```re example
 let isEven = x => x mod 2 == 0;
 
-let s0 = Belt.MutableSet.fromArray([|1,2,3,4,5|]);
-let s1 = s0->Belt.MutableSet.keep(isEven);
+let s0 = Belt.MutableSet.Int.fromArray([|1,2,3,4,5|]);
+let s1 = s0->Belt.MutableSet.Int.keep(isEven);
 
-s1->Belt.MutableSet.toArray; /* [|2, 4|] */
+s1->Belt.MutableSet.Int.toArray; /* [|2, 4|] */
 ```
 
 ## partitionU
@@ -395,11 +395,11 @@ let partition: (t, value => bool) => (t, t);
 ```re example
 let isOdd = x => x mod 2 != 0;
 
-let s0 = Belt.MutableSet.fromArray([|1,2,3,4,5|]);
-let (s1, s2) = s0->Belt.MutableSet.partition(isOdd);
+let s0 = Belt.MutableSet.Int.fromArray([|1,2,3,4,5|]);
+let (s1, s2) = s0->Belt.MutableSet.Int.partition(isOdd);
 
-s1->Belt.MutableSet.toArray; /* [|1,3,5|] */
-s2->Belt.MutableSet.toArray; /* [|2,4|] */
+s1->Belt.MutableSet.Int.toArray; /* [|1,3,5|] */
+s2->Belt.MutableSet.Int.toArray; /* [|2,4|] */
 ```
 
 ## size
@@ -411,9 +411,9 @@ let size: t => int;
 Returns size of the set.
 
 ```re example
-let s0 = Belt.MutableSet.fromArray([|1,2,3,4|]);
+let s0 = Belt.MutableSet.Int.fromArray([|1,2,3,4|]);
 
-s0->Belt.MutableSet.size; /* 4 */
+s0->Belt.MutableSet.Int.size; /* 4 */
 ```
 
 ## toList
@@ -425,9 +425,9 @@ let toList: t => list(value);
 Returns list of ordered set elements.
 
 ```re example
-let s0 = Belt.MutableSet.fromArray([|3,2,1,5|]);
+let s0 = Belt.MutableSet.Int.fromArray([|3,2,1,5|]);
 
-s0->Belt.MutableSet.toList; /* [1,2,3,5] */
+s0->Belt.MutableSet.Int.toList; /* [1,2,3,5] */
 ```
 
 ## toArray
@@ -439,9 +439,9 @@ let toArray: t => array(value);
 Returns array of ordered set elements.
 
 ```re example
-let s0 = Belt.MutableSet.fromArray([|3,2,1,5|]);
+let s0 = Belt.MutableSet.Int.fromArray([|3,2,1,5|]);
 
-s0->Belt.MutableSet.toArray; /* [|1,2,3,5|] */
+s0->Belt.MutableSet.Int.toArray; /* [|1,2,3,5|] */
 ```
 
 ## minimum
@@ -453,11 +453,11 @@ let minimum: t => option(value);
 Returns minimum value of the collection. `None` if collection is empty.
 
 ```re example
-let s0 = Belt.MutableSet.make();
-let s1 = Belt.MutableSet.fromArray([|3,2,1,5|]);
+let s0 = Belt.MutableSet.Int.make();
+let s1 = Belt.MutableSet.Int.fromArray([|3,2,1,5|]);
 
-s0->Belt.MutableSet.minimum; /* None */
-s1->Belt.MutableSet.minimum; /* Some(1) */
+s0->Belt.MutableSet.Int.minimum; /* None */
+s1->Belt.MutableSet.Int.minimum; /* Some(1) */
 ```
 
 ## minUndefined
@@ -469,11 +469,11 @@ let minUndefined: t => Js.undefined(value);
 Returns minimum value of the collection. `undefined` if collection is empty.
 
 ```re example
-let s0 = Belt.MutableSet.make();
-let s1 = Belt.MutableSet.fromArray([|3,2,1,5|]);
+let s0 = Belt.MutableSet.Int.make();
+let s1 = Belt.MutableSet.Int.fromArray([|3,2,1,5|]);
 
-s0->Belt.MutableSet.minUndefined; /* undefined */
-s1->Belt.MutableSet.minUndefined; /* 1 */
+s0->Belt.MutableSet.Int.minUndefined; /* undefined */
+s1->Belt.MutableSet.Int.minUndefined; /* 1 */
 ```
 
 ## maximum
@@ -485,11 +485,11 @@ let maximum: t => option(value);
 Returns maximum value of the collection. `None` if collection is empty.
 
 ```re example
-let s0 = Belt.MutableSet.make();
-let s1 = Belt.MutableSet.fromArray([|3,2,1,5|]);
+let s0 = Belt.MutableSet.Int.make();
+let s1 = Belt.MutableSet.Int.fromArray([|3,2,1,5|]);
 
-s0->Belt.MutableSet.maximum; /* None */
-s1->Belt.MutableSet.maximum; /* Some(5) */
+s0->Belt.MutableSet.Int.maximum; /* None */
+s1->Belt.MutableSet.Int.maximum; /* Some(5) */
 ```
 
 ## maxUndefined
@@ -501,11 +501,11 @@ let maxUndefined: t => Js.undefined(value);
 Returns maximum value of the collection. `undefined` if collection is empty.
 
 ```re example
-let s0 = Belt.MutableSet.make();
-let s1 = Belt.MutableSet.fromArray([|3,2,1,5|]);
+let s0 = Belt.MutableSet.Int.make();
+let s1 = Belt.MutableSet.Int.fromArray([|3,2,1,5|]);
 
-s0->Belt.MutableSet.maxUndefined; /* undefined */
-s1->Belt.MutableSet.maxUndefined; /* 5 */
+s0->Belt.MutableSet.Int.maxUndefined; /* undefined */
+s1->Belt.MutableSet.Int.maxUndefined; /* 5 */
 ```
 
 ## get
@@ -517,10 +517,10 @@ let get: (t, value) => option(value);
 Returns the reference of the value which is equivalent to value using the comparator specifiecd by this collection. Returns `None` if element does not exist.
 
 ```re example
-let s0 = Belt.MutableSet.fromArray([|1,2,3,4,5|]);
+let s0 = Belt.MutableSet.Int.fromArray([|1,2,3,4,5|]);
 
-s0->Belt.MutableSet.get(3); /* Some(3) */
-s0->Belt.MutableSet.get(20); /* None */
+s0->Belt.MutableSet.Int.get(3); /* Some(3) */
+s0->Belt.MutableSet.Int.get(20); /* None */
 ```
 
 ## getUndefined
@@ -548,13 +548,13 @@ let split: (t, value) => ((t, t), bool);
 Returns a tuple `((smaller, larger), present)`, `present` is true when element exist in set.
 
 ```re example
-let s0 = Belt.MutableSet.fromArray([|1,2,3,4,5|]);
+let s0 = Belt.MutableSet.Int.fromArray([|1,2,3,4,5|]);
 
-let ((smaller, larger), present) = s0->Belt.MutableSet.split(3);
+let ((smaller, larger), present) = s0->Belt.MutableSet.Int.split(3);
 
 present; /* true */
-smaller->Belt.MutableSet.toArray; /* [|1,2|] */
-larger->Belt.MutableSet.toArray; /* [|4,5|] */
+smaller->Belt.MutableSet.Int.toArray; /* [|1,2|] */
+larger->Belt.MutableSet.Int.toArray; /* [|4,5|] */
 
 ```
 

--- a/pages/belt_docs/mutable-set-string.mdx
+++ b/pages/belt_docs/mutable-set-string.mdx
@@ -70,10 +70,10 @@ let copy: t => t;
 Returns copy of a set.
 
 ```re example
-let s0 = Belt.MutableSet.String.fromArray([|1, 3, 2, 4|], ~id=(module IntCmp))
+let s0 = Belt.MutableSet.String.fromArray([|"orange", "apple"|])
 
 let copied = s0->Belt.MutableSet.String.copy;
-copied->Belt.MutableSet.String.toArray /* [|1, 2, 3, 4|] */
+copied->Belt.MutableSet.String.toArray /* [|"apple", "orange"|] */
 ```
 
 ## isEmpty
@@ -116,15 +116,12 @@ let add: (t, value) => unit;
 Adds element to set. If element existed in set, value is unchanged.
 
 ```re example
-let s0 = Belt.MutableSet.String.empty;
-let s1 = s0->Belt.MutableSet.String.add("apple");
-let s2 = s1->Belt.MutableSet.String.add("banana");
-let s3 = s2->Belt.MutableSet.String.add("banana");
-s0->Belt.MutableSet.String.toArray; /* [||] */
-s1->Belt.MutableSet.String.toArray; /* [|"apple"|] */
-s2->Belt.MutableSet.String.toArray; /* [|"apple", "banana"|] */
-s3->Belt.MutableSet.String.toArray; /* [|"apple", "banana"|] */
-s2 == s3; /* true */
+let s0 = Belt.MutableSet.String.make();
+s0->Belt.MutableSet.String.add("apple");
+s0->Belt.MutableSet.String.add("banana");
+s0->Belt.MutableSet.String.add("banana");
+
+s0->Belt.MutableSet.String.toArray; /* [|"apple", "banana"|] */
 ```
 
 ## addCheck
@@ -142,12 +139,10 @@ let mergeMany: (t, array(value)) => unit;
 Adds each element of array to set.
 
 ```re example
-let set = Belt.MutableSet.String.empty;
+let set = Belt.MutableSet.String.make();
 
-let newSet =
-  set->Belt.MutableSet.String.mergeMany([|"apple", "banana", "orange", "strawberry"|]);
-
-newSet->Belt.MutableSet.String.toArray; /* [|"apple", "banana", "orange", "strawberry"|] */
+set->Belt.MutableSet.String.mergeMany([|"apple", "banana", "orange", "strawberry"|]);
+set->Belt.MutableSet.String.toArray; /* [|"apple", "banana", "orange", "strawberry"|] */
 ```
 
 ## remove
@@ -164,7 +159,7 @@ s0->Belt.MutableSet.String.remove("apple");
 s0->Belt.MutableSet.String.remove("banana");
 s0->Belt.MutableSet.String.remove("banana");
 
-s0->Belt.MutableSet.String.toArray; /* [|"orange|] */
+s0->Belt.MutableSet.String.toArray; /* [|"orange"|] */
 ```
 
 ## removeCheck
@@ -293,7 +288,7 @@ Applies function `f` in turn to all elements of set in increasing order.
 let s0 = Belt.MutableSet.String.fromArray([|"banana", "orange", "apple"|]);
 let acc = ref([]);
 s0->Belt.MutableSet.String.forEach(x => {
-  acc := acc->Belt.List.add(x)
+  acc := Belt.List.add(acc^, x)
 });
 acc; /* ["orange", "banana", "apple"] */
 ```
@@ -316,7 +311,7 @@ Applies function `f` to each element of set in increasing order. Function `f` ha
 
 ```re example
 let s0 = Belt.MutableSet.String.fromArray([|"apple", "orange"|]);
-s0->Belt.MutableSet.String.reduce(0, (element, acc) =>
+s0->Belt.MutableSet.String.reduce(0, (acc, element) =>
   acc + String.length(element)
 ); /* 11 */
 ```
@@ -447,7 +442,7 @@ let toArray: t => array(value);
 Returns array of ordered set elements.
 
 ```re example
-let s0 = Belt.MutableSet.String.fromArray([|"apple", "watermelon"|);
+let s0 = Belt.MutableSet.String.fromArray([|"apple", "watermelon"|]);
 
 s0->Belt.MutableSet.String.toArray; /* [|"apple", "watermelon"|] */
 ```
@@ -461,7 +456,7 @@ let minimum: t => option(value);
 Returns minimum value of the collection. `None` if collection is empty.
 
 ```re example
-let s0 = Belt.MutableSet.String.empty;
+let s0 = Belt.MutableSet.String.make();
 let s1 = Belt.MutableSet.String.fromArray([|"apple", "orange"|]);
 
 s0->Belt.MutableSet.String.minimum; /* None */
@@ -477,7 +472,7 @@ let minUndefined: t => Js.undefined(value);
 Returns minimum value of the collection. `undefined` if collection is empty.
 
 ```re example
-let s0 = Belt.MutableSet.String.empty;
+let s0 = Belt.MutableSet.String.make();
 let s1 = Belt.MutableSet.String.fromArray([|"apple", "orange"|]);
 
 s0->Belt.MutableSet.String.minUndefined; /* undefined */
@@ -493,7 +488,7 @@ let maximum: t => option(value);
 Returns maximum value of the collection. `None` if collection is empty.
 
 ```re example
-let s0 = Belt.MutableSet.String.empty;
+let s0 = Belt.MutableSet.String.make();
 let s1 = Belt.MutableSet.String.fromArray([|"apple", "orange"|]);
 
 s0->Belt.MutableSet.String.maximum; /* None */
@@ -509,7 +504,7 @@ let maxUndefined: t => Js.undefined(value);
 Returns maximum value of the collection. `undefined` if collection is empty.
 
 ```re example
-let s0 = Belt.MutableSet.String.empty;
+let s0 = Belt.MutableSet.String.make();
 let s1 = Belt.MutableSet.String.fromArray([|"apple", "orange"|]);
 
 s0->Belt.MutableSet.String.maxUndefined; /* undefined */

--- a/pages/belt_docs/mutable-set.mdx
+++ b/pages/belt_docs/mutable-set.mdx
@@ -14,7 +14,7 @@ It also has three specialized inner modules [Belt.MutableSet.Int](/belt_docs/mut
 </ApiIntro>
 
 ```re example
-module IntCmp =
+module PairComparator =
   Belt.Id.MakeComparable({
     type t = (int, int);
     let cmp = ((a0, a1), (b0, b1)) =>
@@ -26,16 +26,6 @@ module IntCmp =
 
 let mySet = Belt.MutableSet.make(~id=(module PairComparator));
 mySet->Belt.MutableSet.add((1, 2));
-```
-
-The API documentation below will assume a predeclared comparator module for integers, `IntCmp`
-
-```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
 ```
 
 ## t
@@ -73,6 +63,12 @@ let fromArray: (array('value), ~id: id('value, 'id)) => t('value, 'id);
 Creates new set from array of elements.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.fromArray([|1, 3, 2, 4|], ~id=(module IntCmp))
 
 s0->Belt.MutableSet.toArray; /* [|1, 2, 3, 4|] */
@@ -95,6 +91,12 @@ let copy: t('value, 'id) => t('value, 'id);
 Returns copy of a set.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.fromArray([|1, 3, 2, 4|], ~id=(module IntCmp))
 
 let copied = s0->Belt.MutableSet.copy;
@@ -110,6 +112,12 @@ let isEmpty: t('a, 'b) => bool;
 Checks if set is empty.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let empty = Belt.MutableSet.fromArray([||], ~id=(module IntCmp));
 let notEmpty = Belt.MutableSet.fromArray([|1|],~id=(module IntCmp));
 
@@ -126,6 +134,12 @@ let has: (t('value, 'a), 'value) => bool;
 Checks if element exists in set.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let set = Belt.MutableSet.fromArray([|1, 4, 2, 5|], ~id=(module IntCmp));
 
 set->Belt.MutableSet.has(3) /* false */
@@ -141,12 +155,18 @@ let add: (t('value, 'id), 'value) => unit;
 Adds element to set. If element existed in set, value is unchanged.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.make(~id=(module IntCmp));
 s0->Belt.MutableSet.add(1);
 s0->Belt.MutableSet.add(2);
 s0->Belt.MutableSet.add(2);
 
-s3->Belt.MutableSet.toArray; /* [|1, 2|] */
+s0->Belt.MutableSet.toArray; /* [|1, 2|] */
 ```
 
 ## addCheck
@@ -164,6 +184,12 @@ let mergeMany: (t('value, 'id), array('value)) => unit;
 Adds each element of array to set.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let set = Belt.MutableSet.make(~id=(module IntCmp));
 
 set->Belt.MutableSet.mergeMany([|5, 4, 3, 2, 1|]);
@@ -179,6 +205,12 @@ let remove: (t('value, 'id), 'value) => unit;
 Removes element from set. If element wasn't existed in set, value is unchanged.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.fromArray([|2,3,1,4,5|], ~id=(module IntCmp));
 s0->Belt.MutableSet.remove(1);
 s0->Belt.MutableSet.remove(3);
@@ -202,7 +234,13 @@ let removeMany: (t('value, 'id), array('value)) => unit;
 Removes each element of array from set.
 
 ```re example
-let set = Belt.MutableSet.fromArray([1, 2, 3, 4],~id=(module IntCmp));
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
+let set = Belt.MutableSet.fromArray([|1, 2, 3, 4|],~id=(module IntCmp));
 
 set->Belt.MutableSet.removeMany([|5, 4, 3, 2, 1|]);
 set->Belt.MutableSet.toArray; /* [||] */
@@ -217,6 +255,12 @@ let union: (t('value, 'id), t('value, 'id)) => t('value, 'id);
 Returns union of two sets.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
 let s1 = Belt.MutableSet.fromArray([|5,2,3,1,5,4|], ~id=(module IntCmp));
 let union = Belt.MutableSet.union(s0, s1);
@@ -232,6 +276,11 @@ let intersect: (t('value, 'id), t('value, 'id)) => t('value, 'id);
 Returns intersection of two sets.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
 
 let s0 = Belt.MutableSet.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
 let s1 = Belt.MutableSet.fromArray([|5,2,3,1,5,4|], ~id=(module IntCmp));
@@ -248,6 +297,12 @@ let diff: (t('value, 'id), t('value, 'id)) => t('value, 'id);
 Returns elements from first set, not existing in second set.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
 let s1 = Belt.MutableSet.fromArray([|5,2,3,1,5,4|], ~id=(module IntCmp));
 Belt.MutableSet.toArray(Belt.MutableSet.diff(s0, s1)); /* [|6|] */
@@ -263,6 +318,12 @@ let subset: (t('value, 'id), t('value, 'id)) => bool;
 Checks if second set is subset of first set.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
 let s1 = Belt.MutableSet.fromArray([|5,2,3,1,5,4|], ~id=(module IntCmp));
 let s2 = Belt.MutableSet.intersect(s0, s1);
@@ -288,6 +349,12 @@ let eq: (t('value, 'id), t('value, 'id)) => bool;
 Checks if two sets are equal.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.fromArray([|5,2,3|], ~id=(module IntCmp));
 let s1 = Belt.MutableSet.fromArray([|3,2,5|], ~id=(module IntCmp));
 
@@ -311,10 +378,16 @@ let forEach: (t('value, 'id), 'value => unit) => unit;
 Applies function `f` in turn to all elements of set in increasing order.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
 let acc = ref([]);
 s0->Belt.MutableSet.forEach(x => {
-  acc := acc->Belt.List.add(x)
+  acc := Belt.List.add(acc^, x)
 });
 acc; /* [6,5,3,2] */
 ```
@@ -334,9 +407,15 @@ let reduce: (t('value, 'id), 'a, ('a, 'value) => 'a) => 'a;
 Applies function `f` to each element of set in increasing order. Function `f` has two parameters: the item from the set and an “accumulator”, which starts with a value of `initialValue`. `reduce` returns the final value of the accumulator.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
-s0->Belt.MutableSet.reduce([], (element, acc) =>
-  acc->Bs.List.add(element)
+s0->Belt.MutableSet.reduce([], (acc, element) =>
+  acc->Belt.List.add(element)
 ); /* [6,5,3,2] */
 ```
 
@@ -355,6 +434,12 @@ let every: (t('value, 'id), 'value => bool) => bool;
 Checks if all elements of the set satisfy the predicate. Order unspecified.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let isEven = x => x mod 2 == 0;
 
 let s0 = Belt.MutableSet.fromArray([|2,4,6,8|], ~id=(module IntCmp));
@@ -376,6 +461,12 @@ let some: (t('value, 'id), 'value => bool) => bool;
 Checks if at least one element of the set satisfies the predicate.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let isOdd = x => x mod 2 != 0;
 
 let s0 = Belt.MutableSet.fromArray([|1,2,4,6,8|], ~id=(module IntCmp));
@@ -397,6 +488,12 @@ let keep: (t('value, 'id), 'value => bool) => t('value, 'id);
 Returns the set of all elements that satisfy the predicate.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let isEven = x => x mod 2 == 0;
 
 let s0 = Belt.MutableSet.fromArray([|1,2,3,4,5|], ~id=(module IntCmp));
@@ -418,6 +515,12 @@ let partition: (t('value, 'id), 'value => bool) => (t('value, 'id), t('value, 'i
 ```
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let isOdd = x => x mod 2 != 0;
 
 let s0 = Belt.MutableSet.fromArray([|1,2,3,4,5|], ~id=(module IntCmp));
@@ -436,6 +539,12 @@ let size: t('value, 'id) => int;
 Returns size of the set.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.fromArray([|1,2,3,4|], ~id=(module IntCmp));
 
 s0->Belt.MutableSet.size; /* 4 */
@@ -450,6 +559,12 @@ let toList: t('value, 'id) => list('value);
 Returns list of ordered set elements.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.fromArray([|3,2,1,5|], ~id=(module IntCmp));
 
 s0->Belt.MutableSet.toList; /* [1,2,3,5] */
@@ -464,6 +579,12 @@ let toArray: t('value, 'id) => array('value);
 Returns array of ordered set elements.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.fromArray([|3,2,1,5|], ~id=(module IntCmp));
 
 s0->Belt.MutableSet.toArray; /* [|1,2,3,5|] */
@@ -478,6 +599,12 @@ let minimum: t('value, 'id) => option('value);
 Returns minimum value of the collection. `None` if collection is empty.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.make(~id=(module IntCmp));
 let s1 = Belt.MutableSet.fromArray([|3,2,1,5|], ~id=(module IntCmp));
 
@@ -494,6 +621,12 @@ let minUndefined: t('value, 'id) => Js.undefined('value);
 Returns minimum value of the collection. `undefined` if collection is empty.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.make(~id=(module IntCmp));
 let s1 = Belt.MutableSet.fromArray([|3,2,1,5|], ~id=(module IntCmp));
 
@@ -510,6 +643,12 @@ let maximum: t('value, 'id) => option('value);
 Returns maximum value of the collection. `None` if collection is empty.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.make(~id=(module IntCmp));
 let s1 = Belt.MutableSet.fromArray([|3,2,1,5|], ~id=(module IntCmp));
 
@@ -526,6 +665,12 @@ let maxUndefined: t('value, 'id) => Js.undefined('value);
 Returns maximum value of the collection. `undefined` if collection is empty.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.make(~id=(module IntCmp));
 let s1 = Belt.MutableSet.fromArray([|3,2,1,5|], ~id=(module IntCmp));
 
@@ -542,6 +687,12 @@ let get: (t('value, 'id), 'value) => option('value);
 Returns the reference of the value which is equivalent to value using the comparator specifiecd by this collection. Returns `None` if element does not exist.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.fromArray([|1,2,3,4,5|], ~id=(module IntCmp));
 
 s0->Belt.MutableSet.get(3); /* Some(3) */
@@ -573,6 +724,12 @@ let split: (t('value, 'id), 'value) => ((t('value, 'id), t('value, 'id)), bool);
 Returns a tuple `((smaller, larger), present)`, `present` is true when element exist in set.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.MutableSet.fromArray([|1,2,3,4,5|], ~id=(module IntCmp));
 
 let ((smaller, larger), present) = s0->Belt.MutableSet.split(3);

--- a/pages/belt_docs/result.mdx
+++ b/pages/belt_docs/result.mdx
@@ -46,9 +46,9 @@ let getExn: t('a, 'b) => 'a;
 `getExn(res)`: when `res` is `Ok(n)`, returns `n` when `res` is `Error(m)`, raise an exception
 
 ```re example
-getExn(good) == 42;
+Belt.Result.getExn(Belt.Result.Ok(42)) == 42;
 
-getExn(bad); /* raises exception */
+Belt.Result.getExn(Belt.Result.Error("Invalid data")); /* raises exception */
 ```
 
 ## mapWithDefaultU
@@ -67,9 +67,11 @@ let mapWithDefault: (t('a, 'c), 'b, 'a => 'b) => 'b;
 otherwise `default`.
 
 ```re example
-mapWithDefault(good, 0, (x) => x / 2) == 21;
+let ok = Belt.Result.Ok(42)
+Belt.Result.mapWithDefault(ok, 0, (x) => x / 2) == 21;
 
-mapWithDefault(bad, 0, (x) => x / 2) == 0;
+let error = Belt.Result.Error("Invalid data")
+Belt.Result.mapWithDefault(error, 0, (x) => x / 2) == 0;
 ```
 
 ## mapU
@@ -91,9 +93,9 @@ ordinary value.
 ```re example
 let f = (x) => sqrt(float_of_int(x));
 
-map(Ok(64), f) == Ok(8.0);
+Belt.Result.map(Ok(64), f) == Ok(8.0);
 
-map(Error("Invalid data"), f) == Error("Invalid data");
+Belt.Result.map(Error("Invalid data"), f) == Error("Invalid data");
 ```
 
 ## flatMapU
@@ -115,16 +117,16 @@ unchanged. Function `f` takes a value of the same type as `n` and returns a
 ```re example
 let recip = (x) =>
   if (x !== 0.0) {
-    Ok(1.0 /. x);
+    Belt.Result.Ok(1.0 /. x);
   } else {
-    Error("Divide by zero");
+    Belt.Result.Error("Divide by zero");
   };
 
-flatMap(Ok(2.0), recip) == Ok(0.5);
+Belt.Result.flatMap(Ok(2.0), recip) == Ok(0.5);
 
-flatMap(Ok(0.0), recip) == Error("Divide by zero");
+Belt.Result.flatMap(Ok(0.0), recip) == Error("Divide by zero");
 
-flatMap(Error("Already bad"), recip) == Error("Already bad");
+Belt.Result.flatMap(Error("Already bad"), recip) == Error("Already bad");
 ```
 
 ## getWithDefault
@@ -137,9 +139,9 @@ let getWithDefault: (t('a, 'b), 'a) => 'a;
 otherwise `default`
 
 ```re example
-getWithDefault(Ok(42), 0) == 42;
+Belt.Result.getWithDefault(Ok(42), 0) == 42;
 
-getWithDefault(Error("Invalid Data")) == 0;
+Belt.Result.getWithDefault(Error("Invalid Data"), 0) == 0;
 ```
 
 ## isOk
@@ -179,23 +181,23 @@ the form `Error(e)`, return false If both `res1` and `res2` are of the form
 `Error(e)`, return true
 
 ```re example
-let good1 = Ok(42);
+let good1 = Belt.Result.Ok(42);
 
-let good2 = Ok(32);
+let good2 = Belt.Result.Ok(32);
 
-let bad1 = Error("invalid");
+let bad1 = Belt.Result.Error("invalid");
 
-let bad2 = Error("really invalid");
+let bad2 = Belt.Result.Error("really invalid");
 
 let mod10equal = (a, b) => a mod 10 === b mod 10;
 
-eq(good1, good2, mod10equal) == true;
+Belt.Result.eq(good1, good2, mod10equal) == true;
 
-eq(good1, bad1, mod10equal) == false;
+Belt.Result.eq(good1, bad1, mod10equal) == false;
 
-eq(bad2, good2, mod10equal) == false;
+Belt.Result.eq(bad2, good2, mod10equal) == false;
 
-eq(bad1, bad2, mod10equal) == true;
+Belt.Result.eq(bad1, bad2, mod10equal) == true;
 ```
 
 ## cmpU
@@ -222,23 +224,23 @@ return -1 (nothing is less than something) If `res1` is of the form `Ok(n)` and
 both `res1` and `res2` are of the form `Error(e)`, return 0 (equal)
 
 ```re example
-let good1 = Ok(59);
+let good1 = Belt.Result.Ok(59);
 
-let good2 = Ok(37);
+let good2 = Belt.Result.Ok(37);
 
-let bad1 = Error("invalid");
+let bad1 = Belt.Result.Error("invalid");
 
-let bad2 = Error("really invalid");
+let bad2 = Belt.Result.Error("really invalid");
 
 let mod10cmp = (a, b) => Pervasives.compare(a mod 10, b mod 10);
 
-cmp(Ok(39), Ok(57), mod10cmp) == 1;
+Belt.Result.cmp(Ok(39), Ok(57), mod10cmp) == 1;
 
-cmp(Ok(57), Ok(39), mod10cmp) == (-1);
+Belt.Result.cmp(Ok(57), Ok(39), mod10cmp) == (-1);
 
-cmp(Ok(39), Error("y"), mod10cmp) == 1;
+Belt.Result.cmp(Ok(39), Error("y"), mod10cmp) == 1;
 
-cmp(Error("x"), Ok(57), mod10cmp) == (-1);
+Belt.Result.cmp(Error("x"), Ok(57), mod10cmp) == (-1);
 
-cmp(Error("x"), Error("y"), mod10cmp) == 0;
+Belt.Result.cmp(Error("x"), Error("y"), mod10cmp) == 0;
 ```

--- a/pages/belt_docs/set-dict.mdx
+++ b/pages/belt_docs/set-dict.mdx
@@ -10,16 +10,6 @@ This module seprate identity from data, it is a bit more verboe but slightly mor
 
 </ApiIntro>
 
-The API documentation below will assume a predeclared comparator module for integers, `IntCmp`
-
-```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-```
-
 ## t
 
 ```re sig
@@ -45,7 +35,7 @@ let empty: t('value, 'id);
 ```
 
 ```re example
-let s0 = Belt.Set.Dict.Int.empty;
+let s0 = Belt.Set.Dict.empty;
 ```
 
 ## fromArray
@@ -57,6 +47,12 @@ let fromArray: (array('value), ~cmp: cmp('value, 'id)) => t('value, 'id);
 Creates new set from array of elements.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.Dict.fromArray([|1, 3, 2, 4|], ~cmp=IntCmp.cmp);
 
 s0->Belt.Set.Dict.toArray; /* [|1, 2, 3, 4|] */
@@ -79,6 +75,12 @@ let isEmpty: t('a, 'b) => bool;
 Checks if set is empty.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let empty = Belt.Set.Dict.fromArray([||], ~cmp=IntCmp.cmp);
 let notEmpty = Belt.Set.Dict.fromArray([|1|], ~cmp=IntCmp.cmp);
 
@@ -95,6 +97,12 @@ let has: (t('value, 'id), 'value, ~cmp: cmp('value, 'id)) => bool;
 Checks if element exists in set.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let set = Belt.Set.Dict.fromArray([|1, 4, 2, 5|], ~cmp=IntCmp.cmp);
 
 set->Belt.Set.Dict.has(3) /* false */
@@ -110,6 +118,12 @@ let add: (t('value, 'id), 'value, ~cmp: cmp('value, 'id)) => t('value, 'id);
 Adds element to set. If element existed in set, value is unchanged.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.Dict.empty;
 let s1 = s0->Belt.Set.Dict.add(1, ~cmp=IntCmp.cmp);
 let s2 = s1->Belt.Set.Dict.add(2, ~cmp=IntCmp.cmp);
@@ -130,6 +144,12 @@ let mergeMany: (t('value, 'id), array('value), ~cmp: cmp('value, 'id)) => t('val
 Adds each element of array to set. Unlike [add](#add), the reference of return value might be changed even if all values in array already exist in set
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let set = Belt.Set.Dict.empty;
 
 let newSet = set->Belt.Set.Dict.mergeMany([|5, 4, 3, 2, 1|], ~cmp=IntCmp.cmp);
@@ -145,6 +165,12 @@ let remove: (t('value, 'id), 'value, ~cmp: cmp('value, 'id)) => t('value, 'id);
 Removes element from set. If element wasn't existed in set, value is unchanged.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.Dict.fromArray([|2,3,1,4,5|], ~cmp=IntCmp.cmp);
 let s1 = s0->Belt.Set.Dict.remove(1, ~cmp=IntCmp.cmp);
 let s2 = s1->Belt.Set.Dict.remove(3, ~cmp=IntCmp.cmp);
@@ -164,7 +190,13 @@ let removeMany: (t('value, 'id), array('value), ~cmp: cmp('value, 'id)) => t('va
 Removes each element of array from set. Unlike [remove](#remove), the reference of return value might be changed even if any values in array not existed in set.
 
 ```re example
-let set = Belt.Set.Dict.fromArray([1, 2, 3, 4],~cmp=IntCmp.cmp);
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
+let set = Belt.Set.Dict.fromArray([|1, 2, 3, 4|],~cmp=IntCmp.cmp);
 
 let newSet = set->Belt.Set.Dict.removeMany([|5, 4, 3, 2, 1|], ~cmp=IntCmp.cmp);
 newSet->Belt.Set.Dict.toArray; /* [||] */
@@ -179,6 +211,12 @@ let union: (t('value, 'id), t('value, 'id), ~cmp: cmp('value, 'id)) => t('value,
 Returns union of two sets.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.Dict.fromArray([|5,2,3,5,6|], ~cmp=IntCmp.cmp);
 let s1 = Belt.Set.Dict.fromArray([|5,2,3,1,5,4|], ~cmp=IntCmp.cmp);
 let union = Belt.Set.Dict.union(s0, s1, ~cmp=IntCmp.cmp);
@@ -194,6 +232,11 @@ let intersect: (t('value, 'id), t('value, 'id), ~cmp: cmp('value, 'id)) => t('va
 Returns intersection of two sets.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
 
 let s0 = Belt.Set.Dict.fromArray([|5,2,3,5,6|], ~cmp=IntCmp.cmp);
 let s1 = Belt.Set.Dict.fromArray([|5,2,3,1,5,4|], ~cmp=IntCmp.cmp);
@@ -210,6 +253,12 @@ let diff: (t('value, 'id), t('value, 'id), ~cmp: cmp('value, 'id)) => t('value, 
 Returns elements from first set, not existing in second set.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.Dict.fromArray([|5,2,3,5,6|], ~cmp=IntCmp.cmp);
 let s1 = Belt.Set.Dict.fromArray([|5,2,3,1,5,4|], ~cmp=IntCmp.cmp);
 
@@ -229,6 +278,12 @@ let subset: (t('value, 'id), t('value, 'id), ~cmp: cmp('value, 'id)) => bool;
 Checks if second set is subset of first set.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.Dict.fromArray([|5,2,3,5,6|], ~cmp=IntCmp.cmp);
 let s1 = Belt.Set.Dict.fromArray([|5,2,3,1,5,4|], ~cmp=IntCmp.cmp);
 let s2 = Belt.Set.Dict.intersect(s0, s1, ~cmp=IntCmp.cmp);
@@ -254,6 +309,12 @@ let eq: (t('value, 'id), t('value, 'id), ~cmp: cmp('value, 'id)) => bool;
 Checks if two sets are equal.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.Dict.fromArray([|5,2,3|], ~cmp=IntCmp.cmp);
 let s1 = Belt.Set.Dict.fromArray([|3,2,5|], ~cmp=IntCmp.cmp);
 
@@ -277,10 +338,16 @@ let forEach: (t('value, 'id), 'value => unit) => unit;
 Applies function `f` in turn to all elements of set in increasing order.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.Dict.fromArray([|5,2,3,5,6|], ~cmp=IntCmp.cmp);
 let acc = ref([]);
 s0->Belt.Set.Dict.forEach(x => {
-  acc := acc->Belt.List.add(x)
+  acc := Belt.List.add(acc^, x)
 });
 acc; /* [6,5,3,2] */
 ```
@@ -300,9 +367,15 @@ let reduce: (t('value, 'id), 'a, ('a, 'value) => 'a) => 'a;
 Applies function `f` to each element of set in increasing order. Function `f` has two parameters: the item from the set and an “accumulator”, which starts with a value of `initialValue`. `reduce` returns the final value of the accumulator.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.Dict.fromArray([|5,2,3,5,6|], ~cmp=IntCmp.cmp);
-s0->Belt.Set.Dict.reduce([], (element, acc) =>
-  acc->Bs.List.add(element)
+s0->Belt.Set.Dict.reduce([], (acc, element) =>
+  acc->Belt.List.add(element)
 ); /* [6,5,3,2] */
 ```
 
@@ -321,6 +394,12 @@ let every: (t('value, 'id), 'value => bool) => bool;
 Checks if all elements of the set satisfy the predicate. Order unspecified.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let isEven = x => x mod 2 == 0;
 
 let s0 = Belt.Set.Dict.fromArray([|2,4,6,8|], ~cmp=IntCmp.cmp);
@@ -342,6 +421,12 @@ let some: (t('value, 'id), 'value => bool) => bool;
 Checks if at least one element of the set satisfies the predicate.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let isOdd = x => x mod 2 != 0;
 
 let s0 = Belt.Set.Dict.fromArray([|1,2,4,6,8|], ~cmp=IntCmp.cmp);
@@ -363,6 +448,12 @@ let keep: (t('value, 'id), 'value => bool) => t('value, 'id);
 Returns the set of all elements that satisfy the predicate.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let isEven = x => x mod 2 == 0;
 
 let s0 = Belt.Set.Dict.fromArray([|1,2,3,4,5|], ~cmp=IntCmp.cmp);
@@ -386,6 +477,12 @@ let partition: (t('value, 'id), 'value => bool) => (t('value, 'id), t('value, 'i
 Returns a pair of sets, where first is the set of all the elements of set that satisfy the predicate, and second is the set of all the elements of set that do not satisfy the predicate.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let isOdd = x => x mod 2 != 0;
 
 let s0 = Belt.Set.Dict.fromArray([|1,2,3,4,5|], ~cmp=IntCmp.cmp);
@@ -404,6 +501,12 @@ let size: t('value, 'id) => int;
 Returns size of the set.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.Dict.fromArray([|1,2,3,4|], ~cmp=IntCmp.cmp);
 
 s0->Belt.Set.Dict.size; /* 4 */
@@ -418,6 +521,12 @@ let toList: t('value, 'id) => list('value);
 Returns list of ordered set elements.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.Dict.fromArray([|3,2,1,5|], ~cmp=IntCmp.cmp);
 
 s0->Belt.Set.Dict.toList; /* [1,2,3,5] */
@@ -432,6 +541,12 @@ let toArray: t('value, 'id) => array('value);
 Returns array of ordered set elements.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.Dict.fromArray([|3,2,1,5|], ~cmp=IntCmp.cmp);
 
 s0->Belt.Set.Dict.toArray; /* [|1,2,3,5|] */
@@ -446,7 +561,13 @@ let minimum: t('value, 'id) => option('value);
 Returns minimum value of the collection. `None` if collection is empty.
 
 ```re example
-let s0 = Belt.Set.Dict.make(~cmp=IntCmp.cmp);
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
+let s0 = Belt.Set.Dict.empty;
 let s1 = Belt.Set.Dict.fromArray([|3,2,1,5|], ~cmp=IntCmp.cmp);
 
 s0->Belt.Set.Dict.minimum; /* None */
@@ -462,7 +583,13 @@ let minUndefined: t('value, 'id) => Js.undefined('value);
 Returns minimum value of the collection. `undefined` if collection is empty.
 
 ```re example
-let s0 = Belt.Set.Dict.make(~cmp=IntCmp.cmp);
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
+let s0 = Belt.Set.Dict.empty;
 let s1 = Belt.Set.Dict.fromArray([|3,2,1,5|], ~cmp=IntCmp.cmp);
 
 s0->Belt.Set.Dict.minUndefined; /* undefined */
@@ -478,7 +605,13 @@ let maximum: t('value, 'id) => option('value);
 Returns maximum value of the collection. `None` if collection is empty.
 
 ```re example
-let s0 = Belt.Set.Dict.make(~cmp=IntCmp.cmp);
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
+let s0 = Belt.Set.Dict.empty;
 let s1 = Belt.Set.Dict.fromArray([|3,2,1,5|], ~cmp=IntCmp.cmp);
 
 s0->Belt.Set.Dict.maximum; /* None */
@@ -494,7 +627,13 @@ let maxUndefined: t('value, 'id) => Js.undefined('value);
 Returns maximum value of the collection. `undefined` if collection is empty.
 
 ```re example
-let s0 = Belt.Set.Dict.make(~cmp=IntCmp.cmp);
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
+let s0 = Belt.Set.Dict.empty;
 let s1 = Belt.Set.Dict.fromArray([|3,2,1,5|], ~cmp=IntCmp.cmp);
 
 s0->Belt.Set.Dict.maxUndefined; /* undefined */
@@ -510,6 +649,12 @@ let get: (t('value, 'id), 'value, ~cmp: cmp('value, 'id)) => option('value);
 Returns the reference of the value which is equivalent to value using the comparator specifiecd by this collection. Returns `None` if element does not exist.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.Dict.fromArray([|1,2,3,4,5|], ~cmp=IntCmp.cmp);
 
 s0->Belt.Set.Dict.get(3, ~cmp=IntCmp.cmp); /* Some(3) */
@@ -541,6 +686,12 @@ let split: (t('value, 'id), 'value, ~cmp: cmp('value, 'id)) => ((t('value, 'id),
 Returns a tuple `((smaller, larger), present)`, `present` is true when element exist in set.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.Dict.fromArray([|1,2,3,4,5|], ~cmp=IntCmp.cmp);
 
 let ((smaller, larger), present) =

--- a/pages/belt_docs/set-int.mdx
+++ b/pages/belt_docs/set-int.mdx
@@ -49,7 +49,7 @@ Creates new set from array of elements.
 ```re example
 let s0 = Belt.Set.Int.fromArray([|1, 3, 2, 4|])
 
-so->Belt.Set.Int.toArray; /* [|1, 2, 3, 4|] */
+s0->Belt.Set.Int.toArray; /* [|1, 2, 3, 4|] */
 ```
 
 ## fromSortedArrayUnsafe
@@ -154,7 +154,7 @@ let removeMany: (t, array(value)) => t;
 Removes each element of array from set. Unlike [remove](#remove), the reference of return value might be changed even if any values in array not existed in set.
 
 ```re example
-let set = Belt.Set.Int.fromArray([1, 2, 3, 4]);
+let set = Belt.Set.Int.fromArray([|1, 2, 3, 4|]);
 
 let newSet = set->Belt.Set.Int.removeMany([|5, 4, 3, 2, 1|]);
 newSet->Belt.Set.Int.toArray; /* [||] */
@@ -266,7 +266,7 @@ Applies function `f` in turn to all elements of set in increasing order.
 let s0 = Belt.Set.Int.fromArray([|5,2,3,5,6|]);
 let acc = ref([]);
 s0->Belt.Set.Int.forEach(x => {
-  acc := acc->Belt.List.add(x)
+  acc := Belt.List.add(acc^, x)
 });
 acc; /* [6,5,3,2] */
 ```
@@ -287,8 +287,8 @@ Applies function `f` to each element of set in increasing order. Function `f` ha
 
 ```re example
 let s0 = Belt.Set.Int.fromArray([|5,2,3,5,6|]);
-s0->Belt.Set.Int.reduce([], (element, acc) =>
-  acc->Bs.List.add(element)
+s0->Belt.Set.Int.reduce([], (acc, element) =>
+  acc->Belt.List.add(element)
 ); /* [6,5,3,2] */
 ```
 
@@ -524,12 +524,12 @@ Same as [get](#get) but raise when element does not exist.
 let split: (t, value) => ((t, t), bool);
 ```
 
-Returns a triple `(l, present, r)`, where `l` is the set of elements of set that are strictly less than value, `r` is the set of elements of set that are strictly greater than value, `present` is `false` if set contains no element equal to value, or `true` if set contains an element equal to value.
+Returns a tuple `((l, r), present)`, where `l` is the set of elements of set that are strictly less than value, `r` is the set of elements of set that are strictly greater than value, `present` is `false` if set contains no element equal to value, or `true` if set contains an element equal to value.
 
 ```re example
 let s0 = Belt.Set.Int.fromArray([|1,2,3,4,5|]);
 
-let (smaller, present, larger) = s0->Belt.Set.Int.split(3);
+let ((smaller, larger), present) = s0->Belt.Set.Int.split(3);
 
 present; /* true */
 smaller->Belt.Set.Int.toArray; /* [|1,2|] */

--- a/pages/belt_docs/set-string.mdx
+++ b/pages/belt_docs/set-string.mdx
@@ -49,7 +49,7 @@ Creates new set from array of elements.
 ```re example
 let s0 = Belt.Set.String.fromArray([|"apple", "orange", "banana"|])
 
-so->Belt.Set.String.toArray; /* [|"apple", "banana", "orange"|] */
+s0->Belt.Set.String.toArray; /* [|"apple", "banana", "orange"|] */
 ```
 
 ## fromSortedArrayUnsafe
@@ -143,7 +143,7 @@ let s2 = s1->Belt.Set.String.remove("banana");
 let s3 = s2->Belt.Set.String.remove("banana");
 
 s1->Belt.Set.String.toArray; /* [|"orange", "banana"|] */
-s2->Belt.Set.String.toArray; /* [|"orange|] */
+s2->Belt.Set.String.toArray; /* [|"orange"|] */
 s2 == s3; /* true */
 ```
 
@@ -267,7 +267,7 @@ Applies function `f` in turn to all elements of set in increasing order.
 let s0 = Belt.Set.String.fromArray([|"banana", "orange", "apple"|]);
 let acc = ref([]);
 s0->Belt.Set.String.forEach(x => {
-  acc := acc->Belt.List.add(x)
+  acc := Belt.List.add(acc^, x)
 });
 acc; /* ["orange", "banana", "apple"] */
 ```
@@ -288,7 +288,7 @@ Applies function `f` to each element of set in increasing order. Function `f` ha
 
 ```re example
 let s0 = Belt.Set.String.fromArray([|"apple", "orange"|]);
-s0->Belt.Set.String.reduce(0, (element, acc) =>
+s0->Belt.Set.String.reduce(0, (acc, element) =>
   acc + String.length(element)
 ); /* 11 */
 ```
@@ -419,7 +419,7 @@ let toArray: t => array(value);
 Returns array of ordered set elements.
 
 ```re example
-let s0 = Belt.Set.String.fromArray([|"apple", "watermelon"|);
+let s0 = Belt.Set.String.fromArray([|"apple", "watermelon"|]);
 
 s0->Belt.Set.String.toArray; /* [|"apple", "watermelon"|] */
 ```
@@ -525,12 +525,12 @@ See [get](#get) - raise when element does not exist.
 let split: (t, value) => ((t, t), bool);
 ```
 
-Returns a triple `(l, present, r)`, where `l` is the set of elements of set that are strictly less than value, `r` is the set of elements of set that are strictly greater than value, `present` is `false` if set contains no element equal to value, or `true` if set contains an element equal to value.
+Returns a triple `((l, r), present)`, where `l` is the set of elements of set that are strictly less than value, `r` is the set of elements of set that are strictly greater than value, `present` is `false` if set contains no element equal to value, or `true` if set contains an element equal to value.
 
 ```re example
 let s0 = Belt.Set.String.fromArray([|"apple", "banana", "orange"|]);
 
-let (smaller, present, larger) = s0->Belt.Set.String.split("banana");
+let ((smaller, larger), present) = s0->Belt.Set.String.split("banana");
 
 present; /* true */
 smaller->Belt.Set.String.toArray; /* [|"apple"|] */

--- a/pages/belt_docs/set.mdx
+++ b/pages/belt_docs/set.mdx
@@ -28,16 +28,6 @@ let mySet = Belt.Set.make(~id=(module PairComparator));
 let mySet2 = Belt.Set.add(mySet, (1, 2));
 ```
 
-The API documentation below will assume a predeclared comparator module for integers, `IntCmp`
-
-```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-```
-
 ## t
 
 ```re sig
@@ -65,6 +55,12 @@ let make: (~id: id('value, 'id)) => t('value, 'id);
 Creates a new set by taking in the comparator
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let set = Belt.Set.make(~id=(module IntCmp));
 ```
 
@@ -77,6 +73,12 @@ let fromArray: (array('value), ~id: id('value, 'id)) => t('value, 'id);
 Creates new set from array of elements.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.fromArray([|1, 3, 2, 4|], ~id=(module IntCmp))
 
 s0->Belt.Set.toArray; /* [|1, 2, 3, 4|] */
@@ -99,6 +101,12 @@ let isEmpty: t('a, 'b) => bool;
 Checks if set is empty.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let empty = Belt.Set.fromArray([||], ~id=(module IntCmp));
 let notEmpty = Belt.Set.fromArray([|1|],~id=(module IntCmp));
 
@@ -115,6 +123,12 @@ let has: (t('value, 'id), 'value) => bool;
 Checks if element exists in set.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let set = Belt.Set.fromArray([|1, 4, 2, 5|], ~id=(module IntCmp));
 
 set->Belt.Set.has(3) /* false */
@@ -130,6 +144,12 @@ let add: (t('value, 'id), 'value) => t('value, 'id);
 Adds element to set. If element existed in set, value is unchanged.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.make(~id=(module IntCmp));
 let s1 = s0->Belt.Set.add(1);
 let s2 = s1->Belt.Set.add(2);
@@ -150,6 +170,12 @@ let mergeMany: (t('value, 'id), array('value)) => t('value, 'id);
 Adds each element of array to set. Unlike [add](#add), the reference of return value might be changed even if all values in array already exist in set
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let set = Belt.Set.make(~id=(module IntCmp));
 
 let newSet = set->Belt.Set.mergeMany([|5, 4, 3, 2, 1|]);
@@ -165,6 +191,12 @@ let remove: (t('value, 'id), 'value) => t('value, 'id);
 Removes element from set. If element wasn't existed in set, value is unchanged.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.fromArray([|2,3,1,4,5|], ~id=(module IntCmp));
 let s1 = s0->Belt.Set.remove(1);
 let s2 = s1->Belt.Set.remove(3);
@@ -184,7 +216,13 @@ let removeMany: (t('value, 'id), array('value)) => t('value, 'id);
 Removes each element of array from set. Unlike [remove](#remove), the reference of return value might be changed even if any values in array not existed in set.
 
 ```re example
-let set = Belt.Set.fromArray([1, 2, 3, 4],~id=(module IntCmp));
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
+let set = Belt.Set.fromArray([|1, 2, 3, 4|],~id=(module IntCmp));
 
 let newSet = set->Belt.Set.removeMany([|5, 4, 3, 2, 1|]);
 newSet->Belt.Set.toArray; /* [||] */
@@ -199,6 +237,12 @@ let union: (t('value, 'id), t('value, 'id)) => t('value, 'id);
 Returns union of two sets.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
 let s1 = Belt.Set.fromArray([|5,2,3,1,5,4|], ~id=(module IntCmp));
 let union = Belt.Set.union(s0, s1);
@@ -214,6 +258,11 @@ let intersect: (t('value, 'id), t('value, 'id)) => t('value, 'id);
 Returns intersection of two sets.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
 
 let s0 = Belt.Set.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
 let s1 = Belt.Set.fromArray([|5,2,3,1,5,4|], ~id=(module IntCmp));
@@ -230,6 +279,12 @@ let diff: (t('value, 'id), t('value, 'id)) => t('value, 'id);
 Returns elements from first set, not existing in second set.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
 let s1 = Belt.Set.fromArray([|5,2,3,1,5,4|], ~id=(module IntCmp));
 Belt.Set.toArray(Belt.Set.diff(s0, s1)); /* [|6|] */
@@ -245,6 +300,12 @@ let subset: (t('value, 'id), t('value, 'id)) => bool;
 Checks if second set is subset of first set.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
 let s1 = Belt.Set.fromArray([|5,2,3,1,5,4|], ~id=(module IntCmp));
 let s2 = Belt.Set.intersect(s0, s1);
@@ -270,6 +331,12 @@ let eq: (t('value, 'id), t('value, 'id)) => bool;
 Checks if two sets are equal.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.fromArray([|5,2,3|], ~id=(module IntCmp));
 let s1 = Belt.Set.fromArray([|3,2,5|], ~id=(module IntCmp));
 
@@ -293,10 +360,16 @@ let forEach: (t('value, 'id), 'value => unit) => unit;
 Applies function `f` in turn to all elements of set in increasing order.
 
 ```re example
-let s0 = Belt.SEt.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
+let s0 = Belt.Set.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
 let acc = ref([]);
 s0->Belt.Set.forEach(x => {
-  acc := acc->Belt.List.add(x)
+  acc := Belt.List.add(acc^, x)
 });
 acc; /* [6,5,3,2] */
 ```
@@ -316,9 +389,15 @@ let reduce: (t('value, 'id), 'a, ('a, 'value) => 'a) => 'a;
 Applies function `f` to each element of set in increasing order. Function `f` has two parameters: the item from the set and an “accumulator”, which starts with a value of `initialValue`. `reduce` returns the final value of the accumulator.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
-s0->Belt.Set.reduce([], (element, acc) =>
-  acc->Bs.List.add(element)
+s0->Belt.Set.reduce([], (acc, element) =>
+  acc->Belt.List.add(element)
 ); /* [6,5,3,2] */
 ```
 
@@ -337,6 +416,12 @@ let every: (t('value, 'id), 'value => bool) => bool;
 Checks if all elements of the set satisfy the predicate. Order unspecified.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let isEven = x => x mod 2 == 0;
 
 let s0 = Belt.Set.fromArray([|2,4,6,8|], ~id=(module IntCmp));
@@ -358,6 +443,12 @@ let some: (t('value, 'id), 'value => bool) => bool;
 Checks if at least one element of the set satisfies the predicate.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let isOdd = x => x mod 2 != 0;
 
 let s0 = Belt.Set.fromArray([|1,2,4,6,8|], ~id=(module IntCmp));
@@ -379,6 +470,12 @@ let keep: (t('value, 'id), 'value => bool) => t('value, 'id);
 Returns the set of all elements that satisfy the predicate.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let isEven = x => x mod 2 == 0;
 
 let s0 = Belt.Set.fromArray([|1,2,3,4,5|], ~id=(module IntCmp));
@@ -402,6 +499,12 @@ let partition: (t('value, 'id), 'value => bool) => (t('value, 'id), t('value, 'i
 Returns a pair of sets, where first is the set of all the elements of set that satisfy the predicate, and second is the set of all the elements of set that do not satisfy the predicate.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let isOdd = x => x mod 2 != 0;
 
 let s0 = Belt.Set.fromArray([|1,2,3,4,5|], ~id=(module IntCmp));
@@ -420,6 +523,12 @@ let size: t('value, 'id) => int;
 Returns size of the set.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.fromArray([|1,2,3,4|], ~id=(module IntCmp));
 
 s0->Belt.Set.size; /* 4 */
@@ -434,6 +543,12 @@ let toArray: t('value, 'id) => array('value);
 Returns array of ordered set elements.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.fromArray([|3,2,1,5|], ~id=(module IntCmp));
 
 s0->Belt.Set.toArray; /* [|1,2,3,5|] */
@@ -448,6 +563,12 @@ let toList: t('value, 'id) => list('value);
 Returns list of ordered set elements.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.fromArray([|3,2,1,5|], ~id=(module IntCmp));
 
 s0->Belt.Set.toList; /* [1,2,3,5] */
@@ -462,6 +583,12 @@ let minimum: t('value, 'id) => option('value);
 Returns minimum value of the collection. `None` if collection is empty.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.make(~id=(module IntCmp));
 let s1 = Belt.Set.fromArray([|3,2,1,5|], ~id=(module IntCmp));
 
@@ -478,6 +605,12 @@ let minUndefined: t('value, 'id) => Js.undefined('value);
 Returns minimum value of the collection. `undefined` if collection is empty.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.make(~id=(module IntCmp));
 let s1 = Belt.Set.fromArray([|3,2,1,5|], ~id=(module IntCmp));
 
@@ -490,6 +623,12 @@ s1->Belt.Set.minUndefined; /* 1 */
 Returns maximum value of the collection. `None` if collection is empty.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.make(~id=(module IntCmp));
 let s1 = Belt.Set.fromArray([|3,2,1,5|], ~id=(module IntCmp));
 
@@ -506,6 +645,12 @@ let maxUndefined: t('value, 'id) => Js.undefined('value);
 Returns maximum value of the collection. `undefined` if collection is empty.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.make(~id=(module IntCmp));
 let s1 = Belt.Set.fromArray([|3,2,1,5|], ~id=(module IntCmp));
 
@@ -522,6 +667,12 @@ let get: (t('value, 'id), 'value) => option('value);
 Returns the reference of the value which is equivalent to value using the comparator specifiecd by this collection. Returns `None` if element does not exist.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.fromArray([|1,2,3,4,5|], ~id=(module IntCmp));
 
 s0->Belt.Set.get(3); /* Some(3) */
@@ -553,6 +704,12 @@ let split: (t('value, 'id), 'value) => ((t('value, 'id), t('value, 'id)), bool);
 Returns a tuple `((smaller, larger), present)`, `present` is true when element exist in set.
 
 ```re example
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+
 let s0 = Belt.Set.fromArray([|1,2,3,4,5|], ~id=(module IntCmp));
 
 let ((smaller, larger), present) = s0->Belt.Set.split(3);

--- a/pages/belt_docs/sort-array.mdx
+++ b/pages/belt_docs/sort-array.mdx
@@ -34,13 +34,13 @@ let strictlySortedLength: (array('a), ('a, 'a) => bool) => int;
 `strictlySortedLenght(xs, cmp);` return `+n` means increasing order `-n` means negative order
 
 ```re example
-strictlySortedLength([|1, 2, 3, 4, 3|], (x, y) => x < y) == 4;
+Belt.SortArray.strictlySortedLength([|1, 2, 3, 4, 3|], (x, y) => x < y) == 4;
 
-strictlySortedLength([||], (x, y) => x < y) == 0;
+Belt.SortArray.strictlySortedLength([||], (x, y) => x < y) == 0;
 
-strictlySortedLength([|1|], (x, y) => x < y) == 1;
+Belt.SortArray.strictlySortedLength([|1|], (x, y) => x < y) == 1;
 
-strictlySortedLength([|4, 3, 2, 1|], (x, y) => x < y) == (-4);
+Belt.SortArray.strictlySortedLength([|4, 3, 2, 1|], (x, y) => x < y) == (-4);
 ```
 
 ## isSortedU
@@ -108,7 +108,7 @@ smaller than all elements return `-1` since `lnot(-1) == 0` if `key` is larger
 than all elements return `lnot(-1) == 0` since `lnot(- (len + 1)) == len`
 
 ```re example
-binarySearchBy([|1, 2, 3, 4, 33, 35, 36|], 33) == 4;
+Belt.SortArray.binarySearchBy([|1, 2, 3, 4, 33, 35, 36|], 33, Pervasives.compare) == 4;
 
-lnot(binarySearchBy([|1, 3, 5, 7|], 4)) == 2;
+lnot(Belt.SortArray.binarySearchBy([|1, 3, 5, 7|], 4, Pervasives.compare)) == 2;
 ```


### PR DESCRIPTION
Fixes `Set`, `Set.Int`, `Set.String`, `Set.Dict`, `MutableSet`, `MutableSet.Int`, `MutableSet.String`, `SortArray`, `HashSet`, `Map.Int`, `Map.String`, `Result` examples.
All tests are passing so I assume it resolves #29 and resolves #27.