### PR TITLE
fix mapReverse2 example formatting

### DIFF
--- a/pages/belt_docs/list.mdx
+++ b/pages/belt_docs/list.mdx
@@ -533,11 +533,9 @@ let mapReverse2: (t('a), t('b), ('a, 'b) => 'c) => t('c);
 
 Equivalent to: `zipBy(xs, ys, f)->reverse`
 
-````
-
 ```re example
 Belt.List.mapReverse2([1, 2, 3], [1, 2], (+)); /* [4, 2] */
-````
+```
 
 ## forEach2
 


### PR DESCRIPTION
Before:
![Screenshot 2019-10-08 at 08 23 04](https://user-images.githubusercontent.com/5595092/66371871-e1941f00-e9a4-11e9-8698-f3d0aef43794.png)

After:

![Screenshot 2019-10-08 at 08 24 12](https://user-images.githubusercontent.com/5595092/66371945-08eaec00-e9a5-11e9-89aa-8bde7f25db58.png)
