### PR TITLE
Add prelude support

### DIFF
--- a/pages/belt_docs/set.mdx
+++ b/pages/belt_docs/set.mdx
@@ -29,7 +29,7 @@ let mySet2 = Belt.Set.add(mySet, (1, 2));
 ```
 
 **Note:** This module's examples will assume a predeclared module for integers
-called `CmpInt`. It is declared like this:
+called `IntCmp`. It is declared like this:
 
 ```re prelude
 module IntCmp =

--- a/pages/belt_docs/set.mdx
+++ b/pages/belt_docs/set.mdx
@@ -28,6 +28,17 @@ let mySet = Belt.Set.make(~id=(module PairComparator));
 let mySet2 = Belt.Set.add(mySet, (1, 2));
 ```
 
+**Note:** This module's examples will assume a predeclared module for integers
+called `CmpInt`. It is declared like this:
+
+```re prelude
+module IntCmp =
+  Belt.Id.MakeComparable({
+    type t = int;
+    let cmp = Pervasives.compare;
+  });
+```
+
 ## t
 
 ```re sig
@@ -55,12 +66,6 @@ let make: (~id: id('value, 'id)) => t('value, 'id);
 Creates a new set by taking in the comparator
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let set = Belt.Set.make(~id=(module IntCmp));
 ```
 
@@ -73,12 +78,6 @@ let fromArray: (array('value), ~id: id('value, 'id)) => t('value, 'id);
 Creates new set from array of elements.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.fromArray([|1, 3, 2, 4|], ~id=(module IntCmp))
 
 s0->Belt.Set.toArray; /* [|1, 2, 3, 4|] */
@@ -101,12 +100,6 @@ let isEmpty: t('a, 'b) => bool;
 Checks if set is empty.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let empty = Belt.Set.fromArray([||], ~id=(module IntCmp));
 let notEmpty = Belt.Set.fromArray([|1|],~id=(module IntCmp));
 
@@ -123,12 +116,6 @@ let has: (t('value, 'id), 'value) => bool;
 Checks if element exists in set.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let set = Belt.Set.fromArray([|1, 4, 2, 5|], ~id=(module IntCmp));
 
 set->Belt.Set.has(3) /* false */
@@ -144,12 +131,6 @@ let add: (t('value, 'id), 'value) => t('value, 'id);
 Adds element to set. If element existed in set, value is unchanged.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.make(~id=(module IntCmp));
 let s1 = s0->Belt.Set.add(1);
 let s2 = s1->Belt.Set.add(2);
@@ -170,12 +151,6 @@ let mergeMany: (t('value, 'id), array('value)) => t('value, 'id);
 Adds each element of array to set. Unlike [add](#add), the reference of return value might be changed even if all values in array already exist in set
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let set = Belt.Set.make(~id=(module IntCmp));
 
 let newSet = set->Belt.Set.mergeMany([|5, 4, 3, 2, 1|]);
@@ -191,12 +166,6 @@ let remove: (t('value, 'id), 'value) => t('value, 'id);
 Removes element from set. If element wasn't existed in set, value is unchanged.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.fromArray([|2,3,1,4,5|], ~id=(module IntCmp));
 let s1 = s0->Belt.Set.remove(1);
 let s2 = s1->Belt.Set.remove(3);
@@ -216,12 +185,6 @@ let removeMany: (t('value, 'id), array('value)) => t('value, 'id);
 Removes each element of array from set. Unlike [remove](#remove), the reference of return value might be changed even if any values in array not existed in set.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let set = Belt.Set.fromArray([|1, 2, 3, 4|],~id=(module IntCmp));
 
 let newSet = set->Belt.Set.removeMany([|5, 4, 3, 2, 1|]);
@@ -237,12 +200,6 @@ let union: (t('value, 'id), t('value, 'id)) => t('value, 'id);
 Returns union of two sets.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
 let s1 = Belt.Set.fromArray([|5,2,3,1,5,4|], ~id=(module IntCmp));
 let union = Belt.Set.union(s0, s1);
@@ -258,12 +215,6 @@ let intersect: (t('value, 'id), t('value, 'id)) => t('value, 'id);
 Returns intersection of two sets.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
 let s1 = Belt.Set.fromArray([|5,2,3,1,5,4|], ~id=(module IntCmp));
 let intersect = Belt.Set.intersect(s0, s1);
@@ -279,12 +230,6 @@ let diff: (t('value, 'id), t('value, 'id)) => t('value, 'id);
 Returns elements from first set, not existing in second set.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
 let s1 = Belt.Set.fromArray([|5,2,3,1,5,4|], ~id=(module IntCmp));
 Belt.Set.toArray(Belt.Set.diff(s0, s1)); /* [|6|] */
@@ -300,12 +245,6 @@ let subset: (t('value, 'id), t('value, 'id)) => bool;
 Checks if second set is subset of first set.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
 let s1 = Belt.Set.fromArray([|5,2,3,1,5,4|], ~id=(module IntCmp));
 let s2 = Belt.Set.intersect(s0, s1);
@@ -331,12 +270,6 @@ let eq: (t('value, 'id), t('value, 'id)) => bool;
 Checks if two sets are equal.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.fromArray([|5,2,3|], ~id=(module IntCmp));
 let s1 = Belt.Set.fromArray([|3,2,5|], ~id=(module IntCmp));
 
@@ -360,12 +293,6 @@ let forEach: (t('value, 'id), 'value => unit) => unit;
 Applies function `f` in turn to all elements of set in increasing order.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
 let acc = ref([]);
 s0->Belt.Set.forEach(x => {
@@ -389,12 +316,6 @@ let reduce: (t('value, 'id), 'a, ('a, 'value) => 'a) => 'a;
 Applies function `f` to each element of set in increasing order. Function `f` has two parameters: the item from the set and an “accumulator”, which starts with a value of `initialValue`. `reduce` returns the final value of the accumulator.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.fromArray([|5,2,3,5,6|], ~id=(module IntCmp));
 s0->Belt.Set.reduce([], (acc, element) =>
   acc->Belt.List.add(element)
@@ -416,12 +337,6 @@ let every: (t('value, 'id), 'value => bool) => bool;
 Checks if all elements of the set satisfy the predicate. Order unspecified.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let isEven = x => x mod 2 == 0;
 
 let s0 = Belt.Set.fromArray([|2,4,6,8|], ~id=(module IntCmp));
@@ -443,12 +358,6 @@ let some: (t('value, 'id), 'value => bool) => bool;
 Checks if at least one element of the set satisfies the predicate.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let isOdd = x => x mod 2 != 0;
 
 let s0 = Belt.Set.fromArray([|1,2,4,6,8|], ~id=(module IntCmp));
@@ -470,12 +379,6 @@ let keep: (t('value, 'id), 'value => bool) => t('value, 'id);
 Returns the set of all elements that satisfy the predicate.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let isEven = x => x mod 2 == 0;
 
 let s0 = Belt.Set.fromArray([|1,2,3,4,5|], ~id=(module IntCmp));
@@ -499,12 +402,6 @@ let partition: (t('value, 'id), 'value => bool) => (t('value, 'id), t('value, 'i
 Returns a pair of sets, where first is the set of all the elements of set that satisfy the predicate, and second is the set of all the elements of set that do not satisfy the predicate.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let isOdd = x => x mod 2 != 0;
 
 let s0 = Belt.Set.fromArray([|1,2,3,4,5|], ~id=(module IntCmp));
@@ -523,12 +420,6 @@ let size: t('value, 'id) => int;
 Returns size of the set.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.fromArray([|1,2,3,4|], ~id=(module IntCmp));
 
 s0->Belt.Set.size; /* 4 */
@@ -543,12 +434,6 @@ let toArray: t('value, 'id) => array('value);
 Returns array of ordered set elements.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.fromArray([|3,2,1,5|], ~id=(module IntCmp));
 
 s0->Belt.Set.toArray; /* [|1,2,3,5|] */
@@ -563,12 +448,6 @@ let toList: t('value, 'id) => list('value);
 Returns list of ordered set elements.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.fromArray([|3,2,1,5|], ~id=(module IntCmp));
 
 s0->Belt.Set.toList; /* [1,2,3,5] */
@@ -583,12 +462,6 @@ let minimum: t('value, 'id) => option('value);
 Returns minimum value of the collection. `None` if collection is empty.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.make(~id=(module IntCmp));
 let s1 = Belt.Set.fromArray([|3,2,1,5|], ~id=(module IntCmp));
 
@@ -605,12 +478,6 @@ let minUndefined: t('value, 'id) => Js.undefined('value);
 Returns minimum value of the collection. `undefined` if collection is empty.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.make(~id=(module IntCmp));
 let s1 = Belt.Set.fromArray([|3,2,1,5|], ~id=(module IntCmp));
 
@@ -623,12 +490,6 @@ s1->Belt.Set.minUndefined; /* 1 */
 Returns maximum value of the collection. `None` if collection is empty.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.make(~id=(module IntCmp));
 let s1 = Belt.Set.fromArray([|3,2,1,5|], ~id=(module IntCmp));
 
@@ -645,12 +506,6 @@ let maxUndefined: t('value, 'id) => Js.undefined('value);
 Returns maximum value of the collection. `undefined` if collection is empty.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.make(~id=(module IntCmp));
 let s1 = Belt.Set.fromArray([|3,2,1,5|], ~id=(module IntCmp));
 
@@ -667,12 +522,6 @@ let get: (t('value, 'id), 'value) => option('value);
 Returns the reference of the value which is equivalent to value using the comparator specifiecd by this collection. Returns `None` if element does not exist.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.fromArray([|1,2,3,4,5|], ~id=(module IntCmp));
 
 s0->Belt.Set.get(3); /* Some(3) */
@@ -704,12 +553,6 @@ let split: (t('value, 'id), 'value) => ((t('value, 'id), t('value, 'id)), bool);
 Returns a tuple `((smaller, larger), present)`, `present` is true when element exist in set.
 
 ```re example
-module IntCmp =
-  Belt.Id.MakeComparable({
-    type t = int;
-    let cmp = Pervasives.compare;
-  });
-
 let s0 = Belt.Set.fromArray([|1,2,3,4,5|], ~id=(module IntCmp));
 
 let ((smaller, larger), present) = s0->Belt.Set.split(3);


### PR DESCRIPTION
This PR will enable prelude snippet support. What does that mean? Some modules require some shared code to express examples more easily (and to reduce repetitive writing). Such as the `pages/belt_docs/set.mdx` file.

How to use it?

Preferably in the beginning of the module description, you add your prelude as a codeblock with a `re prelude` metastring. This will still render the codeblock like any other example, but in the testing script, it will do following extra tasks:

- It will test all preludes before executing any examples (if a prelude doesn't work, all examples will fail anyways)
- If the preludes do work, the test script will find and concatenate all prelude codeblocks, and prepend them to each example code before execution

Also this PR fixes an issue with line number parsing / replacement when a syntax parse error occurs.

Fixes #55 