### PR TITLE
fix index page typos

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -30,9 +30,9 @@ We are currently in the process of extracting Belt documentation from the
 BuckleScript source code. Each module (e.g. `Belt.List`) will have its own
 dedicated markdown file.
 
-**Possiblilties for contributions:**
+**Possibilities for contributions:**
 
-- Extract documentation from the original source code w/ convertion to Reason syntax
+- Extract documentation from the original source code w/ conversion to Reason syntax
 - Improvement of usage examples
 - Working on mechanics to automatically verify & test the examples inside the markdown for CI
 


### PR DESCRIPTION
Just a couple small typo fixes to the index page I noticed as I was looking at the contributions section.