### PR TITLE
Fix #67: Make sidebar items focusable in FF.

### DIFF
--- a/layouts/BeltDocsLayout.bs.js
+++ b/layouts/BeltDocsLayout.bs.js
@@ -509,7 +509,8 @@ function BeltDocsLayout$Sidebar$NavUl(Props) {
                         var active = match ? " bg-bs-purple-lighten-95 text-bs-pink rounded -ml-1 px-2 font-bold block " : "";
                         return React.createElement("li", {
                                     key: m[/* name */0],
-                                    className: hidden + " leading-5 w-4/5"
+                                    className: hidden + " leading-5 w-4/5",
+                                    tabIndex: 0
                                   }, React.createElement("a", {
                                         className: "hover:text-bs-purple " + active,
                                         href: m[/* href */1]

--- a/layouts/BeltDocsLayout.re
+++ b/layouts/BeltDocsLayout.re
@@ -252,7 +252,10 @@ module Sidebar = {
                isItemActive(m)
                  ? " bg-bs-purple-lighten-95 text-bs-pink rounded -ml-1 px-2 font-bold block "
                  : "";
-             <li key={m.name} className={hidden ++ " leading-5 w-4/5"}>
+             <li
+               key={m.name}
+               className={hidden ++ " leading-5 w-4/5"}
+               tabIndex=0>
                <a href={m.href} className={"hover:text-bs-purple " ++ active}>
                  m.name->s
                </a>


### PR DESCRIPTION
According to MDN, to make non-interactive elements (like `div`, `span` or `li`) tab-able, one needs to set `tabindex=0` on such an element.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets