### PR TITLE
Introduction to the Js module, including information about data-first vs. data-last

### DIFF
--- a/pages/apis/javascript/latest/belt.mdx
+++ b/pages/apis/javascript/latest/belt.mdx
@@ -13,7 +13,7 @@ and [Belt.Array](/belt_docs/array) instead of `Array` or [Js.Array](/js_docs/arr
 
 Belt is currently mostly covering collection types. It has no string or
 date functions yet, although Belt.String is in the works. (In the meantime,
-use [Js.String2](/js_docs/string-2) for string functions and [Js.Date](js_docs/date)
+use [Js.String](/js_docs/string) for string functions and [Js.Date](js_docs/date)
 for date functions.)
 
 ## Motivation

--- a/pages/apis/javascript/latest/belt.mdx
+++ b/pages/apis/javascript/latest/belt.mdx
@@ -7,13 +7,13 @@ The preferred standard library for Reason when targeting JavaScript
 (browser, node, React Native).
 
 It is recommended to use the modules from Belt rather than from the
-OCaml standard library or from the [Js](/js_docs) namespace, e.g. use
-[Belt.List](belt_docs/list) instead of `List` or [Js.List](/js_docs/list)
-and [Belt.Array](/belt_docs/array) instead of `Array` or [Js.Array](/js_docs/array).
+OCaml standard library or from the [Js](/apis/javascript/latest/js) namespace, e.g. use
+[Belt.List](/apis/javascript/latest/belt/list) instead of `List` or [Js.List](/apis/javascript/latest/js/list)
+and [Belt.Array](/apis/javascript/latest/belt/array) instead of `Array` or [Js.Array](/apis/javascript/latest/js/array).
 
 Belt is currently mostly covering collection types. It has no string or
 date functions yet, although Belt.String is in the works. (In the meantime,
-use [Js.String](/js_docs/string) for string functions and [Js.Date](js_docs/date)
+use [Js.String](/apis/javascript/latest/js/string) for string functions and [Js.Date](/apis/javascript/latest/js/date)
 for date functions.)
 
 ## Motivation

--- a/pages/apis/javascript/latest/belt.mdx
+++ b/pages/apis/javascript/latest/belt.mdx
@@ -7,16 +7,14 @@ The preferred standard library for Reason when targeting JavaScript
 (browser, node, React Native).
 
 It is recommended to use the modules from Belt rather than from the
-OCaml standard library or from the Js namespace, e.g. use
-[Belt.List](/apis/javascript/latest/belt/list) instead of `List` or [Js.List](/apis/javascript/latest/js/list)
-and [Belt.Array](/apis/javascript/latest/belt/array) instead of `Array` or [Js.Array](/apis/javascript/latest/js/array).
+OCaml standard library or from the [Js](/js_docs) namespace, e.g. use
+[Belt.List](belt_docs/list) instead of `List` or [Js.List](/js_docs/list)
+and [Belt.Array](/belt_docs/array) instead of `Array` or [Js.Array](/js_docs/array).
 
 Belt is currently mostly covering collection types. It has no string or
-date functions yet, although Belt.String is in the works. In the meantime,
-use
-
-- [Js.String2](/apis/javascript/latest/js/string-2) for string functions
-- [Js.Date](/apis/javascript/latest/js/date) for date functions
+date functions yet, although Belt.String is in the works. (In the meantime,
+use [Js.String2](/js_docs/string-2) for string functions and [Js.Date](js_docs/date)
+for date functions.)
 
 ## Motivation
 
@@ -27,7 +25,7 @@ since the original OCaml standard library was not written with JS in mind.
 To achieve this, Belt provides:
 
 - A consistent naming convention familiar to JS developers ([camelCase](https://en.wikipedia.org/wiki/Camel_case))
-- A consistent argument order familiar to JS Developers (see [Pipe First](#Pipe%20First))  
+- A consistent argument order familiar to JS Developers (see [Pipe First](#Pipe%20First))
 - Safety by default: A Belt function will never throw exceptions, unless it is
   indicated explicitly in the function name (suffix "Exn").
 - Better performance and smaller code size running on the JS platform
@@ -57,16 +55,16 @@ into your `bsconfig.json`.
 
 ## Pipe First
 
-The argument order of Belt functions follows the "Pipe First" convention.
+The argument order of Belt functions follows the "Data-First" convention.
 I.e. the object they act on (e.g. a list or an array) will always be
 the first argument.
 
-This way, the pipe first operator can be used nicely with the Belt APIs,
+This way, the _pipe first operator_ `->` can be used nicely with the Belt APIs,
 giving a similar feel to method invocations in OOP languages and allowing
 easy chaining of Belt API calls.
 
-For more information about the "Pipe First" argument order and the
-trade-offs compared to "Pipe Last", see
+For more information about the data-first argument order and the
+trade-offs compared to data-last, see
 [this blog post](https://www.javierchavarri.com/data-first-and-data-last-a-comparison/).
 
 Example:
@@ -130,7 +128,7 @@ For example, Belt has the following set modules:
 When we create a collection library for a custom data type we need a way to
 provide a comparator function. Take Set for example, suppose its element type
 is a pair of ints, it needs a custom compare function that takes two tuples and
-returns their order. The Set could not just be typed as Set.t (int * int) , its
+returns their order. The Set could not just be typed as Set.t (int \* int) , its
 customized compare function needs to manifest itself in the signature,
 otherwise, if the user creates another customized compare function, the two
 collection could mix which would result in runtime error.
@@ -179,4 +177,3 @@ let mySet2: t((int, int), Comparable2.identity);
 
 `Comparable1.identity` and `Comparable2.identity` are not the same using our
 encoding scheme.
-

--- a/pages/apis/javascript/latest/js.mdx
+++ b/pages/apis/javascript/latest/js.mdx
@@ -11,9 +11,14 @@ or the JavaScript
 [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
 classes.
 
-When a correpsonding module is available in the [Belt](belt_docs) standard library,
+It is meant as a zero-abstraction interop layer and therefore directly exposes
+JavaScript functions as they are, even when their behavior should be considered unsafe
+(e.g. modifying an array in place using [Js.Array.push](/js_docs/array#push)).
+
+Therefore, when a correpsonding module is available in the [Belt](belt_docs) standard library,
 it is recommended to use the Belt version rather than the Js version.
-For example, you should prefer [Belt.Array](belt_docs/array) to [Js.Array](js_docs/array).
+For example, you should prefer [Belt.Array](belt_docs/array) to [Js.Array](js_docs/array)
+and [Belt.Map.String](http://localhost:3000/belt_docs/map-string) to [Js.Dict](/js_docs/dict).
 
 ## Argument Order
 

--- a/pages/apis/javascript/latest/js.mdx
+++ b/pages/apis/javascript/latest/js.mdx
@@ -3,7 +3,7 @@ export default Prose.make;
 
 # Js
 
-The [Js](/js_docs) module mostly contains Reason bindings to _standard JavaScript APIs_
+The Js module mostly contains Reason bindings to _standard JavaScript APIs_
 like [console.log](https://developer.mozilla.org/en-US/docs/Web/API/Console/log),
 or the JavaScript
 [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String),
@@ -11,7 +11,7 @@ or the JavaScript
 [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
 classes.
 
-It is meant as a zero-abstraction interop layer and therefore directly exposes
+It is meant as a zero-abstraction interop layer and directly exposes
 JavaScript functions as they are, even when their behavior should be considered unsafe
 (e.g. modifying an array in place using [Js.Array.push](/js_docs/array#push)).
 
@@ -22,7 +22,7 @@ and [Belt.Map.String](http://localhost:3000/belt_docs/map-string) to [Js.Dict](/
 
 ## Argument Order
 
-For historical reasons, some APIs in the [Js](/js_docs) namespace (e.g. [Js.String](/js_docs/string)) are
+For historical reasons, some APIs in the Js namespace (e.g. [Js.String](/js_docs/string)) are
 using the data-last argument order whereas others (e.g. [Js.Date](js_docs/date)) are using data-first.
 
 For more information about these argument orders and the trade-offs between them, see

--- a/pages/apis/javascript/latest/js.mdx
+++ b/pages/apis/javascript/latest/js.mdx
@@ -13,22 +13,24 @@ classes.
 
 It is meant as a zero-abstraction interop layer and directly exposes
 JavaScript functions as they are, even when their behavior should be considered unsafe
-(e.g. modifying an array in place using [Js.Array.push](/js_docs/array#push)).
+(e.g. modifying an array in place using [Js.Array.push](/apis/javascript/latest/js/array#push)).
 
-Therefore, when a correpsonding module is available in the [Belt](belt_docs) standard library,
+Therefore, when a correpsonding module is available in the [Belt](/apis/javascript/latest/belt) standard library,
 it is recommended to use the Belt version rather than the Js version.
-For example, you should prefer [Belt.Array](belt_docs/array) to [Js.Array](js_docs/array)
-and [Belt.Map.String](http://localhost:3000/belt_docs/map-string) to [Js.Dict](/js_docs/dict).
+For example, you should prefer [Belt.Array](/apis/javascript/latest/belt/array)
+to [Js.Array](/apis/javascript/latest/js/array)
+and [Belt.Map.String](http://localhost:3000/apis/javascript/latest/belt/map-string)
+to [Js.Dict](/apis/javascript/latest/js/dict).
 
 ## Argument Order
 
-For historical reasons, some APIs in the Js namespace (e.g. [Js.String](/js_docs/string)) are
-using the data-last argument order whereas others (e.g. [Js.Date](js_docs/date)) are using data-first.
+For historical reasons, some APIs in the Js namespace (e.g. [Js.String](/apis/javascript/latest/js/string)) are
+using the data-last argument order whereas others (e.g. [Js.Date](/apis/javascript/latest/js/date)) are using data-first.
 
 For more information about these argument orders and the trade-offs between them, see
 [this blog post](https://www.javierchavarri.com/data-first-and-data-last-a-comparison/).
 
-_Eventually, all modules in the [Js](/js_docs) namespace are going to be migrated to data-first though._
+_Eventually, all modules in the Js namespace are going to be migrated to data-first though._
 
 In the meantime, there are several options for dealing with the data-last APIs:
 
@@ -48,8 +50,8 @@ Js.log(Js.String.startsWith("Re", "Reason"));
 
 ## Js.Xxx2 Modules
 
-For some modules with data-last argument order (e.g. [Js.String](/js_docs/string)),
-there currently exists a matching module suffixed with "2" (e.g. [Js.String2](js_docs/string-2))
+For some modules with data-last argument order (e.g. [Js.String](/apis/javascript/latest/js/string)),
+there currently exists a matching module suffixed with "2" (e.g. [Js.String2](/apis/javascript/latest/js/string-2))
 that uses data-first argument order.
 These `Js.Xxx2` modules are non-public API, so their use is dicouraged.
 

--- a/pages/apis/javascript/latest/js.mdx
+++ b/pages/apis/javascript/latest/js.mdx
@@ -3,14 +3,54 @@ export default Prose.make;
 
 # Js
 
-This library provides bindings and necessary support for JS FFI.
-It contains all bindings into Js namespace.
+The [Js](/js_docs) module mostly contains Reason bindings to *standard JavaScript APIs*
+like [console.log](https://developer.mozilla.org/en-US/docs/Web/API/Console/log),
+or the JavaScript
+[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String),
+[Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date), and
+[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+classes.
+
+When a correpsonding module is available in the [Belt](belt_docs) standard library,
+it is recommended to use the Belt version rather than the Js version.
+For example, you should prefer [Belt.Array](belt_docs/array) to [Js.Array](js_docs/array).
+
+## Pipe First vs. Pipe Last
+
+Reason provides two different pipe operators:
+
+- *Pipe First* `->`, meant for use with *Data-First APIs*
+- *Pipe Last* `|>`, meant for use with *Data-Last APIs*
+
+For more information about the data-first and data-last argument orders and the
+trade-offs between them, see
+[this blog post](https://www.javierchavarri.com/data-first-and-data-last-a-comparison/).
+
+Most Reason APIs targeting JavaScript, like the [Belt](belt_docs) standard library,
+follow the data-first convention and are therefore meant for use with the Pipe First operator `->`.
+
+In the [Js](/js_docs) namespace, however, for historical reasons, there are some
+remaining modules that are still using the data-last convention. These modules
+*are currently being migrated to use data-first*.
+
+While this migration is ongoing, some modules have two versions existing in parallel:
+
+- `Js.Xxx`: data-last version
+- `Js.Xxx2`: data-first version
+
+When the migration is finished, the data-last versions will be deprecated and eventually
+removed. It is therefore recommended to use the data-first versions now.
+
+Example for the two versions existing in parallel:
 
 ```re example
-[|1, 2, 3, 4|]
-->Js.Array2.map(x => x + 1)
-->Js.Array2.reduce((+), 0)
-->Js.log;
+/* Data-last version of the String API (don't use!) */
+Js.log("2019-11-10" |> Js.String.split("-"));
+Js.log("Reason" |> Js.String.startsWith("Re"));
+
+/* Data-first version of the String API (recommended) */
+Js.log("2019-11-10"->Js.String2.split("-"));
+Js.log("Reason"->Js.String2.startsWith("Re"));
 ```
 
 ## Object

--- a/pages/apis/javascript/latest/js.mdx
+++ b/pages/apis/javascript/latest/js.mdx
@@ -3,7 +3,7 @@ export default Prose.make;
 
 # Js
 
-The [Js](/js_docs) module mostly contains Reason bindings to *standard JavaScript APIs*
+The [Js](/js_docs) module mostly contains Reason bindings to _standard JavaScript APIs_
 like [console.log](https://developer.mozilla.org/en-US/docs/Web/API/Console/log),
 or the JavaScript
 [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String),
@@ -15,43 +15,38 @@ When a correpsonding module is available in the [Belt](belt_docs) standard libra
 it is recommended to use the Belt version rather than the Js version.
 For example, you should prefer [Belt.Array](belt_docs/array) to [Js.Array](js_docs/array).
 
-## Pipe First vs. Pipe Last
+## Argument Order
 
-Reason provides two different pipe operators:
+For historical reasons, some APIs in the [Js](/js_docs) namespace (e.g. [Js.String](/js_docs/string)) are
+using the data-last argument order whereas others (e.g. [Js.Date](js_docs/date)) are using data-first.
 
-- *Pipe First* `->`, meant for use with *Data-First APIs*
-- *Pipe Last* `|>`, meant for use with *Data-Last APIs*
-
-For more information about the data-first and data-last argument orders and the
-trade-offs between them, see
+For more information about these argument orders and the trade-offs between them, see
 [this blog post](https://www.javierchavarri.com/data-first-and-data-last-a-comparison/).
 
-Most Reason APIs targeting JavaScript, like the [Belt](belt_docs) standard library,
-follow the data-first convention and are therefore meant for use with the Pipe First operator `->`.
+_Eventually, all modules in the [Js](/js_docs) namespace are going to be migrated to data-first though._
 
-In the [Js](/js_docs) namespace, however, for historical reasons, there are some
-remaining modules that are still using the data-last convention. These modules
-*are currently being migrated to use data-first*.
-
-While this migration is ongoing, some modules have two versions existing in parallel:
-
-- `Js.Xxx`: data-last version
-- `Js.Xxx2`: data-first version
-
-When the migration is finished, the data-last versions will be deprecated and eventually
-removed. It is therefore recommended to use the data-first versions now.
-
-Example for the two versions existing in parallel:
+In the meantime, there are several options for dealing with the data-last APIs:
 
 ```re example
-/* Data-last version of the String API (don't use!) */
+/* Js.String (data-last API used with pipe last operator) */
 Js.log("2019-11-10" |> Js.String.split("-"));
 Js.log("Reason" |> Js.String.startsWith("Re"));
 
-/* Data-first version of the String API (recommended) */
-Js.log("2019-11-10"->Js.String2.split("-"));
-Js.log("Reason"->Js.String2.startsWith("Re"));
+/* Js.String (data-last API used with pipe first operator) */
+Js.log("2019-11-10"->Js.String.split("-", _));
+Js.log("Reason"->Js.String.startsWith("Re", _));
+
+/* Js.String (data-last API used without any piping) */
+Js.log(Js.String.split("-", "2019-11-10"));
+Js.log(Js.String.startsWith("Re", "Reason"));
 ```
+
+## Js.Xxx2 Modules
+
+For some modules with data-last argument order (e.g. [Js.String](/js_docs/string)),
+there currently exists a matching module suffixed with "2" (e.g. [Js.String2](js_docs/string-2))
+that uses data-first argument order.
+These `Js.Xxx2` modules are non-public API, so their use is dicouraged.
 
 ## Object
 


### PR DESCRIPTION
(Also cleaned up/unified some minor things with the Belt introduction I wrote previously.)

I hope that the information regarding the Js.Xxx -> Js.Xxx2 migration is accurate, as I have not received any answer to my questions in https://github.com/BuckleScript/bucklescript/issues/2975#issuecomment-542549940.

@ryyppy In the JS docs, the style is currently somewhat broken as the headlines (h2) are invisible.