### PR TITLE
Improve performance of links

### DIFF
--- a/layouts/ApiLayout.re
+++ b/layouts/ApiLayout.re
@@ -145,9 +145,11 @@ module Sidebar = {
                // to make non-interactive elements (like div, span or li) tab-able
                // see https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets
                tabIndex=0>
-               <a href={m.href} className={{j|hover:text-t-primary|j} ++ active}>
-                 m.name->s
-               </a>
+               <Link href={m.href}>
+                 <a className={{j|hover:text-t-primary|j} ++ active}>
+                   m.name->s
+                 </a>
+               </Link>
              </li>;
            },
          )


### PR DESCRIPTION
I noticed that the links in the side navigation weren't as instant as Next.js links usually are, and then saw that they weren't being wrapped in the `Link` component.

Didn't test this yet, so hope it doesn't break anything!