### PR TITLE
Add pages title

### DIFF
--- a/components/Meta.bs.js
+++ b/components/Meta.bs.js
@@ -1,9 +1,11 @@
 
 
+import * as Util from "../common/Util.bs.js";
 import * as React from "react";
 import * as Head from "next/head";
 
 function Meta(Props) {
+  var title = Props.title;
   return React.createElement(Head.default, {
               children: null
             }, React.createElement("meta", {
@@ -11,7 +13,7 @@ function Meta(Props) {
                 }), React.createElement("meta", {
                   content: "width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, minimal-ui",
                   name: "viewport"
-                }));
+                }), React.createElement("title", undefined, Util.ReactStuff.s(title)));
 }
 
 var Head$1 = 0;

--- a/components/Meta.re
+++ b/components/Meta.re
@@ -1,12 +1,14 @@
 module Head = Next.Head;
+open Util.ReactStuff;
 
 [@react.component]
-let make = () => {
+let make = (~title) => {
   <Head>
     <meta charSet="ISO-8859-1" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, minimal-ui"
     />
+    <title> title->s </title>
   </Head>;
 };

--- a/layouts/BeltDocsLayout.bs.js
+++ b/layouts/BeltDocsLayout.bs.js
@@ -1,5 +1,6 @@
 
 
+import * as Meta from "../components/Meta.bs.js";
 import * as Curry from "bs-platform/lib/es6/curry.js";
 import * as React from "react";
 import * as Js_dict from "bs-platform/lib/es6/js_dict.js";
@@ -422,12 +423,14 @@ function BeltDocsLayout$Docs(Props) {
     components: components,
     sidebar: sidebar,
     route: router.route,
-    children: children
+    children: null
   };
   if (breadcrumbs !== undefined) {
     tmp$1.breadcrumbs = Caml_option.valFromOption(breadcrumbs);
   }
-  return React.createElement(SidebarLayout.make, tmp$1);
+  return React.createElement(SidebarLayout.make, tmp$1, React.createElement(Meta.make, {
+                  title: moduleName + " - ReasonML"
+                }), children);
 }
 
 var Docs = {

--- a/layouts/BeltDocsLayout.re
+++ b/layouts/BeltDocsLayout.re
@@ -203,6 +203,7 @@ module Docs = {
       route={
         router##route;
       }>
+      <Meta title={moduleName ++ " - ReasonML"} />
       children
     </SidebarLayout>;
   };

--- a/layouts/JsDocsLayout.bs.js
+++ b/layouts/JsDocsLayout.bs.js
@@ -1,5 +1,6 @@
 
 
+import * as Meta from "../components/Meta.bs.js";
 import * as Curry from "bs-platform/lib/es6/curry.js";
 import * as React from "react";
 import * as Js_dict from "bs-platform/lib/es6/js_dict.js";
@@ -486,12 +487,14 @@ function JsDocsLayout$Docs(Props) {
     components: components,
     sidebar: sidebar,
     route: router.route,
-    children: children
+    children: null
   };
   if (breadcrumbs !== undefined) {
     tmp$1.breadcrumbs = Caml_option.valFromOption(breadcrumbs);
   }
-  return React.createElement(SidebarLayout.make, tmp$1);
+  return React.createElement(SidebarLayout.make, tmp$1, React.createElement(Meta.make, {
+                  title: moduleName + " - ReasonML"
+                }), children);
 }
 
 var Docs = {

--- a/layouts/JsDocsLayout.re
+++ b/layouts/JsDocsLayout.re
@@ -236,10 +236,11 @@ module Docs = {
       theme=`Js
       components
       sidebar
-      breadcrumbs=?breadcrumbs
+      ?breadcrumbs
       route={
         router##route;
       }>
+      <Meta title={moduleName ++ " - ReasonML"} />
       children
     </SidebarLayout>;
   };

--- a/layouts/MainLayout.bs.js
+++ b/layouts/MainLayout.bs.js
@@ -24,7 +24,9 @@ function MainLayout(Props) {
           return false;
         }));
   var setIsOpen = match$1[1];
-  return React.createElement(React.Fragment, undefined, React.createElement(Meta.make, { }), React.createElement("div", {
+  return React.createElement(React.Fragment, undefined, React.createElement(Meta.make, {
+                  title: "ReasonML"
+                }), React.createElement("div", {
                   className: "mb-32 mt-16"
                 }, React.createElement("div", {
                       className: "w-full text-night font-base"

--- a/layouts/MainLayout.re
+++ b/layouts/MainLayout.re
@@ -10,7 +10,7 @@ let make = (~children, ~components=Mdx.Components.default) => {
   let (isOpen, setIsOpen) = React.useState(() => false);
 
   <>
-    <Meta />
+    <Meta title="ReasonML" />
     <div className="mb-32 mt-16">
       <div className="w-full text-night font-base">
         <Navigation

--- a/layouts/SidebarLayout.bs.js
+++ b/layouts/SidebarLayout.bs.js
@@ -618,7 +618,9 @@ function SidebarLayout(Props) {
                       crumbs: crumbs
                     });
         }));
-  return React.createElement(React.Fragment, undefined, React.createElement(Meta.make, { }), React.createElement("div", {
+  return React.createElement(React.Fragment, undefined, React.createElement(Meta.make, {
+                  title: ""
+                }), React.createElement("div", {
                   className: "mt-16 min-w-20 " + theme$1
                 }, React.createElement("div", {
                       className: "w-full text-night font-base"

--- a/layouts/SidebarLayout.re
+++ b/layouts/SidebarLayout.re
@@ -583,7 +583,7 @@ let make =
     );
 
   <>
-    <Meta />
+    <Meta title="" />
     <div className={"mt-16 min-w-20 " ++ theme}>
       <div className="w-full text-night font-base">
         <Navigation

--- a/scripts/extract-indices.js
+++ b/scripts/extract-indices.js
@@ -97,19 +97,19 @@ const createIndex = result => {
   }, {});
 };
 
-const BELT_MD_DIR = path.join(__dirname, "../pages/apis/javascript/latest/belt");
+const BELT_MD_DIR = path.join(__dirname, "../pages/apis/javascript/latest/");
 const BELT_INDEX_FILE = path.join(
   __dirname,
   "../index_data/belt_api_index.json"
 );
-const beltFiles = glob.sync(`${BELT_MD_DIR}/*.md?(x)`);
+const beltFiles = glob.sync(`${BELT_MD_DIR}{belt/*.md?(x),belt.mdx}`);
 const beltResult = beltFiles.map(processFile);
 const beltIndex = createIndex(beltResult);
 fs.writeFileSync(BELT_INDEX_FILE, JSON.stringify(beltIndex), "utf8");
 
-const JS_MD_DIR = path.join(__dirname, "../pages/apis/javascript/latest/js");
+const JS_MD_DIR = path.join(__dirname, "../pages/apis/javascript/latest/");
 const JS_INDEX_FILE = path.join(__dirname, "../index_data/js_api_index.json");
-const jsFiles = glob.sync(`${JS_MD_DIR}/*.md?(x)`);
+const jsFiles = glob.sync(`${JS_MD_DIR}{js/*.md?(x),js.mdx}`);
 const jsResult = jsFiles.map(processFile);
 const jsIndex = createIndex(jsResult);
 fs.writeFileSync(JS_INDEX_FILE, JSON.stringify(jsIndex), "utf8");


### PR DESCRIPTION
Implements #97, this PR represents an original approach.

About the title format, I propose:
Homepage: ReasonML
Top level pages: {pageName} - ReasonML. Example: Playground - ReasonML
Docs pages: {method} - {nameSpace} - ReasonML. Example: Global - JS - ReasonML.

Please let me know your thoughts.