### PR TITLE
Fix some doc structure issues

### DIFF
--- a/components/Navigation.bs.js
+++ b/components/Navigation.bs.js
@@ -132,7 +132,7 @@ function Navigation$SubNav$DocsLinks(Props) {
   var languageItems = [
     /* tuple */[
       "Introduction",
-      "/docs/manual/latest"
+      "/docs/manual/latest/introduction"
     ],
     /* tuple */[
       "Cheatsheet",
@@ -142,11 +142,11 @@ function Navigation$SubNav$DocsLinks(Props) {
   var recompItems = [
     /* tuple */[
       "Reason Compiler",
-      "/docs/reason-compiler/latest"
+      "/docs/reason-compiler/latest/introduction"
     ],
     /* tuple */[
       "ReasonReact",
-      "/docs/reason-react/latest"
+      "/docs/reason-react/latest/introduction"
     ]
   ];
   var overlineClass = "font-black uppercase text-sm tracking-wide text-primary-80";
@@ -156,7 +156,7 @@ function Navigation$SubNav$DocsLinks(Props) {
             }, React.createElement("div", {
                   className: reTheme + " pb-12 mt-12 border-b border-night last:border-b-0 lg:w-1/3"
                 }, React.createElement(Link.default, {
-                      href: "/docs/manual/latest",
+                      href: "/docs/manual/latest/introduction",
                       children: React.createElement("a", {
                             className: overlineClass
                           }, Util.ReactStuff.s("Language Manual"))
@@ -177,7 +177,7 @@ function Navigation$SubNav$DocsLinks(Props) {
                               }))))), React.createElement("div", {
                   className: jsTheme + " pb-12 mt-12 border-b border-night last:border-b-0 lg:w-1/3"
                 }, React.createElement(Link.default, {
-                      href: "/docs/reason-compiler/latest",
+                      href: "/docs/reason-compiler/latest/introduction",
                       children: React.createElement("a", {
                             className: overlineClass
                           }, Util.ReactStuff.s("JavaScript"))

--- a/components/Navigation.re
+++ b/components/Navigation.re
@@ -156,13 +156,13 @@ module SubNav = {
       let reTheme = ColorTheme.toCN(`Reason);
 
       let languageItems = [|
-        ("Introduction", "/docs/manual/latest"),
+        ("Introduction", "/docs/manual/latest/introduction"),
         ("Cheatsheet", "/docs/manual/latest/syntax-cheatsheet"),
       |];
 
       let recompItems = [|
-        ("Reason Compiler", "/docs/reason-compiler/latest"),
-        ("ReasonReact", "/docs/reason-react/latest"),
+        ("Reason Compiler", "/docs/reason-compiler/latest/introduction"),
+        ("ReasonReact", "/docs/reason-react/latest/introduction"),
         /*("GenType", "/docs/reason-compiler/gentype/latest"),*/
       |];
 
@@ -175,7 +175,7 @@ module SubNav = {
 
       <div className="lg:flex lg:flex-row px-4 max-w-xl">
         <div className={reTheme ++ " " ++ sectionClass}>
-          <Link href="/docs/manual/latest">
+          <Link href="/docs/manual/latest/introduction">
             <a className=overlineClass> "Language Manual"->s </a>
           </Link>
           <ul className=sectionUl>
@@ -201,7 +201,7 @@ module SubNav = {
           </ul>
         </div>
         <div className={jsTheme ++ " " ++ sectionClass}>
-          <Link href="/docs/reason-compiler/latest">
+          <Link href="/docs/reason-compiler/latest/introduction">
             <a className=overlineClass> "JavaScript"->s </a>
           </Link>
           <ul className=sectionUl>

--- a/layouts/ManualDocsLayout.bs.js
+++ b/layouts/ManualDocsLayout.bs.js
@@ -29,10 +29,24 @@ hljs.registerLanguage('json', jsonHighlightJs);
 
 var tocData = (require('../index_data/manual_toc.json'));
 
-var overviewNavs = [{
+var overviewNavs = [
+  {
     name: "Introduction",
-    href: "/docs/manual/latest"
-  }];
+    href: "/docs/manual/latest/introduction"
+  },
+  {
+    name: "Installation",
+    href: "/docs/manual/latest/installation"
+  },
+  {
+    name: "Editor Plugins",
+    href: "/docs/manual/latest/editor-plugins"
+  },
+  {
+    name: "Extra Goodies",
+    href: "/docs/manual/latest/extra-goodies"
+  }
+];
 
 var basicNavs = [
   {
@@ -237,7 +251,7 @@ function ManualDocsLayout$Docs(Props) {
           var prefix_001 = /* :: */Caml_chrome_debugger.simpleVariant("::", [
               {
                 name: "Language Manual",
-                href: "/docs/manual/" + v.version
+                href: "/docs/manual/" + (v.version + "/introduction")
               },
               /* [] */0
             ]);

--- a/layouts/ManualDocsLayout.re
+++ b/layouts/ManualDocsLayout.re
@@ -34,7 +34,10 @@ module Category = DocsLayout.Category;
 module Toc = DocsLayout.Toc;
 
 let overviewNavs = [|
-  NavItem.{name: "Introduction", href: "/docs/manual/latest"},
+  NavItem.{name: "Introduction", href: "/docs/manual/latest/introduction"},
+  {name: "Installation", href: "/docs/manual/latest/installation"},
+  {name: "Editor Plugins", href: "/docs/manual/latest/editor-plugins"},
+  {name: "Extra Goodies", href: "/docs/manual/latest/extra-goodies"},
 |];
 
 let basicNavs = [|
@@ -133,7 +136,7 @@ module Docs = {
           let prefix =
             UrlPath.[
               {name: "Docs", href: "/docs"},
-              {name: "Language Manual", href: "/docs/manual/" ++ version},
+              {name: "Language Manual", href: "/docs/manual/" ++ version ++ "/introduction"},
             ];
           UrlPath.toBreadCrumbs(~prefix, v);
         },

--- a/layouts/ReasonCompilerDocsLayout.bs.js
+++ b/layouts/ReasonCompilerDocsLayout.bs.js
@@ -32,7 +32,7 @@ var tocData = (require('../index_data/reason_compiler_toc.json'));
 var overviewNavs = [
   {
     name: "Introduction",
-    href: "/docs/reason-compiler/latest"
+    href: "/docs/reason-compiler/latest/introduction"
   },
   {
     name: "Installation",
@@ -261,7 +261,7 @@ function ReasonCompilerDocsLayout(Props) {
           var prefix_001 = /* :: */Caml_chrome_debugger.simpleVariant("::", [
               {
                 name: "BuckleScript",
-                href: "/docs/reason-compiler/" + v.version
+                href: "/docs/reason-compiler/" + (v.version + "/introduction")
               },
               /* [] */0
             ]);

--- a/layouts/ReasonCompilerDocsLayout.re
+++ b/layouts/ReasonCompilerDocsLayout.re
@@ -16,7 +16,6 @@ hljs.registerLanguage('sh', bashHighlightJs);
 hljs.registerLanguage('json', jsonHighlightJs);
 |};
 
-open Util.ReactStuff;
 module Link = Next.Link;
 
 // Structure defined by `scripts/extract-tocs.js`
@@ -35,7 +34,7 @@ module Category = DocsLayout.Category;
 module Toc = DocsLayout.Toc;
 
 let overviewNavs = [|
-  NavItem.{name: "Introduction", href: "/docs/reason-compiler/latest"},
+  NavItem.{name: "Introduction", href: "/docs/reason-compiler/latest/introduction"},
   {name: "Installation", href: "/docs/reason-compiler/latest/installation"},
   {name: "New Project", href: "/docs/reason-compiler/latest/new-project"},
   {name: "Try", href: "/docs/reason-compiler/latest/try"},
@@ -216,7 +215,7 @@ let make = (~components=Markdown.default, ~children) => {
             {name: "Docs", href: "/docs"},
             {
               name: "BuckleScript",
-              href: "/docs/reason-compiler/" ++ version,
+              href: "/docs/reason-compiler/" ++ version ++ "/introduction",
             },
           ];
         UrlPath.toBreadCrumbs(~prefix, v);

--- a/layouts/ReasonReactDocsLayout.bs.js
+++ b/layouts/ReasonReactDocsLayout.bs.js
@@ -32,7 +32,7 @@ var tocData = (require('../index_data/reason_react_toc.json'));
 var overviewNavs = [
   {
     name: "Introduction",
-    href: "/docs/reason-react/latest"
+    href: "/docs/reason-react/latest/introduction"
   },
   {
     name: "Installation",
@@ -213,7 +213,7 @@ function ReasonReactDocsLayout(Props) {
           var prefix_001 = /* :: */Caml_chrome_debugger.simpleVariant("::", [
               {
                 name: "ReasonReact",
-                href: "/docs/reason-react/" + v.version
+                href: "/docs/reason-react/" + (v.version + "/introduction")
               },
               /* [] */0
             ]);

--- a/layouts/ReasonReactDocsLayout.re
+++ b/layouts/ReasonReactDocsLayout.re
@@ -34,7 +34,7 @@ module Category = DocsLayout.Category;
 module Toc = DocsLayout.Toc;
 
 let overviewNavs = [|
-  NavItem.{name: "Introduction", href: "/docs/reason-react/latest"},
+  NavItem.{name: "Introduction", href: "/docs/reason-react/latest/introduction"},
   {name: "Installation", href: "/docs/reason-react/latest/installation"},
   {name: "Intro Example", href: "/docs/reason-react/latest/intro-example"},
 |];
@@ -117,7 +117,7 @@ let make = (~components=Markdown.default, ~children) => {
             {name: "Docs", href: "/docs"},
             {
               name: "ReasonReact",
-              href: "/docs/reason-react/" ++ version,
+              href: "/docs/reason-react/" ++ version ++ "/introduction",
             },
           ];
         UrlPath.toBreadCrumbs(~prefix, v);

--- a/pages/docs/manual/latest/extra-goodies.mdx
+++ b/pages/docs/manual/latest/extra-goodies.mdx
@@ -1,6 +1,8 @@
 import { Prose } from "layouts/ManualDocsLayout.bs.js";
 export default Prose.make;
 
+# Extra Goodies
+
 ## Browser Extension: Reason-tools
 
 [Reason-tools](https://github.com/reasonml/reason-tools) lets you quickly toggle between OCaml syntax and Reason syntax when you're browsing tutorials and documentations written in either syntax.

--- a/pages/docs/manual/latest/installation.mdx
+++ b/pages/docs/manual/latest/installation.mdx
@@ -1,7 +1,9 @@
 import { Prose } from "layouts/ManualDocsLayout.bs.js";
 export default Prose.make;
 
-Reason comes by default in [BuckleScript](/docs/reason-compiler/latest), our compiler that turns Reason code into JavaScript code.
+# Installation
+
+Reason comes by default in [BuckleScript](/docs/reason-compiler/latest/introduction), our compiler that turns Reason code into JavaScript code.
 
 **Prerequisite**: either NPM (comes with [node](https://nodejs.org/en/)) or [Yarn](https://yarnpkg.com/en/).
 

--- a/pages/docs/manual/latest/introduction.mdx
+++ b/pages/docs/manual/latest/introduction.mdx
@@ -1,7 +1,7 @@
 import { Prose } from "layouts/ManualDocsLayout.bs.js";
 export default Prose.make;
 
-# Introduction
+# Reason Language Manual
 
 ## What Is Reason?
 
@@ -9,7 +9,7 @@ Reason is not a new language; it's a new syntax and toolchain powered by the bat
 
 In that regard, Reason can be considered as a solidly, statically typed, faster and simpler cousin of JavaScript, minus the historical crufts, plus the features of ES2030 you can use today, and with access to both the JS and the OCaml ecosystem!
 
-Reason compiles to JavaScript thanks to our `Reason Compiler` called [BuckleScript](/docs/reason-compiler/latest), which compiles OCaml/Reason into readable JavaScript with smooth interop. Reason also compiles to fast, barebone assembly, thanks to OCaml itself.
+Reason compiles to JavaScript thanks to our `Reason Compiler` called [BuckleScript](/docs/reason-compiler/latest/introduction), which compiles OCaml/Reason into readable JavaScript with smooth interop. Reason also compiles to fast, barebone assembly, thanks to OCaml itself.
 
 ## Why Reason?
 
@@ -26,10 +26,10 @@ All these decisions made it so that, for common use-cases, the learning curve of
 - **A rock solid type system**. OCaml types have 100% coverage (every line of code), inference (types can be deduced and aren't required to be written manually), and soundness (once it compiles, the types are guaranteed to be accurate).
 - **A focus on simplicity & pragmatism**. Reason allows opt-in side-effect, mutation and objects for familiarity & interop, while keeping the rest of the language pure, immutable and functional.
 - **A focus on performance & size**. Reason is used to compile to JavaScript using the build system, [`bsb`](/docs/reason-compiler/latest/build-overview), which finishes incremental builds in less than 100ms. The resulting output is also [tiny](https://twitter.com/bobzhang1988/status/827562467148623875).
-- **Incremental learning & codebase conversion**. Reap the benefits of a fully typed file from day one. If everything else fails, [paste some raw JavaScript snippets right in your Reason file](latest/interop).
-- **Great ecosystem & tooling**. Use [your favorite editor](./latest/editor-plugins), [your favorite NPM package](latest/libraries), and any of your [favorite](https://github.com/reasonml/reason-react) [existing](https://github.com/reasonml-community/bs-jest) [stack](https://webpack.js.org).
+- **Incremental learning & codebase conversion**. Reap the benefits of a fully typed file from day one. If everything else fails, [paste some raw JavaScript snippets right in your Reason file](interop).
+- **Great ecosystem & tooling**. Use [your favorite editor](./editor-plugins), [your favorite NPM package](./libraries), and any of your [favorite](https://github.com/reasonml/reason-react) [existing](https://github.com/reasonml-community/bs-jest) [stack](https://webpack.js.org).
 
-\* Don't believe it? Check our [JS -> Reason cheat sheet](latest/syntax-cheatsheet) or try a few snippets of Reason in [the playground](//reasonml.github.io/try.html) and observe the output at the right!
+\* Don't believe it? Check our [JS -> Reason cheat sheet](./syntax-cheatsheet) or try a few snippets of Reason in [the playground](//reasonml.github.io/try.html) and observe the output at the right!
 
 ## Why OCaml As The Backing Language? Why Not [My Favorite Language]?
 
@@ -38,7 +38,7 @@ Many backing languages would satisfy the previous section's points; the points b
 - **The ability to compile to native code**. OCaml's native (assembly) startup time is in **single digit milliseconds**. People are already starting to use Reason for native use cases today; meanwhile, we're focusing on adoption through great JavaScript compatibility.
 - **Side-effects, mutation & other escape hatches**. These aren't usually the shiny selling points of a language; but being able to bridge toward a part of a codebase without an elaborate interop/rewrite is crucial for us at Facebook. OCaml defaults to immutable and functional code, but having the escape hatches makes the initial adoption sometimes simply possible.
 - **Implementation polish matters**. OCaml has been refined over two decades and gets better every year.
-- **The language for writing React**. [ReasonReact](/docs/reason-react/latest) demonstrates how naturally React patterns play to the strengths of OCaml/Reason, and ReactJS itself was inspired by the functional, yet pragmatic philosophy of the ML family of languages (as described in the [React To The Future](https://www.youtube.com/watch?v=5fG_lyNuEAw) talk by [jordwalke](https://twitter.com/jordwalke)).
+- **The language for writing React**. [ReasonReact](/docs/reason-react/latest/introduction) demonstrates how naturally React patterns play to the strengths of OCaml/Reason, and ReactJS itself was inspired by the functional, yet pragmatic philosophy of the ML family of languages (as described in the [React To The Future](https://www.youtube.com/watch?v=5fG_lyNuEAw) talk by [jordwalke](https://twitter.com/jordwalke)).
 - **Welcoming, growing community**. The Reason community is welcoming of newcomers. The community has members from all over the world. Join [the Discord channel](https://discord.gg/reasonml) and ask for help. Stick around to share what you've learned with other newcomers.
 
 ## Reason isn't for you?

--- a/pages/docs/reason-compiler/latest/comparison-to-jsoo.mdx
+++ b/pages/docs/reason-compiler/latest/comparison-to-jsoo.mdx
@@ -11,4 +11,4 @@ However, there are a few areas that BuckleScript approaches differently:
 - Js_of_ocaml focuses more on existing OCaml ecosystem (OPAM) while BuckleScript’s major goal is to target NPM/Yarn and existing JS workflows.
 - Js_of_ocaml and BuckleScript have slightly different runtime encoding in several places. For example, BuckleScript encodes OCaml Array as JS Array while js_of_ocaml requires its index 0 to be of value 0.
 
-See also the [Introduction](../latest) page for more info on BuckleScript's emphasis.
+See also the [Introduction](./introduction) page for more info on BuckleScript's emphasis.

--- a/pages/docs/reason-compiler/latest/concepts-overview.mdx
+++ b/pages/docs/reason-compiler/latest/concepts-overview.mdx
@@ -7,7 +7,7 @@ Before starting the next few sections, here are a helpful things to know:
 
 ## OCaml
 
-This is the backing of BuckleScript. BuckleScript is a fork of OCaml, specifically `v4.02.3` (upgrade impending!). This doc site assumes basic knowledge of OCaml; you can learn OCaml through [Real World OCaml](https://realworldocaml.org/) or, if you're learning Reason anyway, start with the [Reason Manual](/docs/manual/latest).
+This is the backing of BuckleScript. BuckleScript is a fork of OCaml, specifically `v4.02.3` (upgrade impending!). This doc site assumes basic knowledge of OCaml; you can learn OCaml through [Real World OCaml](https://realworldocaml.org/) or, if you're learning Reason anyway, start with the [Reason Manual](/docs/manual/latest/introduction).
 
 **This documentation site will mostly cover just the extra bits we've added to OCaml to enable good JS interoperability**.
 

--- a/pages/docs/reason-compiler/latest/introduction.mdx
+++ b/pages/docs/reason-compiler/latest/introduction.mdx
@@ -1,7 +1,7 @@
 import { make } from "layouts/ReasonCompilerDocsLayout.bs.js";
 export default make;
 
-# Introduction
+# The Reason Compiler
 
 ## BuckleScript
 

--- a/pages/docs/reason-react/latest/installation.mdx
+++ b/pages/docs/reason-react/latest/installation.mdx
@@ -7,7 +7,7 @@ export default make;
 
 ## BuckleScript
 
-[BuckleScript](/docs/reason-compiler/latest) compiles ReasonML code to JavaScript. You can get it with:
+[BuckleScript](/docs/reason-compiler/latest/introduction) compiles ReasonML code to JavaScript. You can get it with:
 
 ```sh
 npm install --global bs-platform@6.2.1

--- a/pages/docs/reason-react/latest/introduction.mdx
+++ b/pages/docs/reason-react/latest/introduction.mdx
@@ -3,7 +3,7 @@ export default make;
 
 # Introduction
 
-ReasonReact is a safer, simpler way to build [React](https://reactjs.org/) components, in [Reason](/docs/manual/latest).
+ReasonReact is a safer, simpler way to build [React](https://reactjs.org/) components, in [Reason](/docs/manual/latest/introduction).
 
 By leveraging the latter's great type system, expressive language features and smooth interoperability with JS, ReasonReact packs ReactJS' features into an API that is:
 


### PR DESCRIPTION
- Move /docs/manual/latest.mdx to /docs/manual/latest/introduction.mdx
- Same for reason-compiler and reason-react
- Make sure all links point to the new urls
- Makes the breadcrumbs show up on each introduction page