### PR TITLE
Added information about array access type errors

### DIFF
--- a/pages/apis/javascript/latest/belt.mdx
+++ b/pages/apis/javascript/latest/belt.mdx
@@ -144,7 +144,7 @@ let k = letters[10]; /* k == None */
 Although we've fixed the problem where `k` raises an exception, we now have a type error when trying to capitalize `a`. There are a few things going on here:
 
 - Reason transforms array index access to the function `Array.get`. So `letters[0]` is the same as `Array.get(letters, 0)`. 
-- This compiles to use whichever `Array` module is in scope. If you `open Belt`, then it uses `Belt.Array`.
+- The compiler uses whichever `Array` module is in scope. If you `open Belt`, then it uses `Belt.Array`.
 - `Belt.Array.get` returns values wrapped in options, so `letters[0] == Some("a")`. 
 
 Fortunately, this is easy to fix:
@@ -167,7 +167,7 @@ let capitalA = a->Option.map(Js.String2.toUpperCase);
 let k = letters[10]; /* k == None */
 ```
 
-With that little bit of tweaking, our code now compiles successfully and is 100% type safe!
+With that little bit of tweaking, our code now compiles successfully and is 100% free of runtime errors!
 
 ### A special encoding for collection safety
 

--- a/pages/apis/javascript/latest/belt.mdx
+++ b/pages/apis/javascript/latest/belt.mdx
@@ -126,8 +126,8 @@ One common confusion comes from the way Belt handles array access. It differs fr
 
 ```reason
 let letters = [|"a", "b", "c"|];
-let a = letters[0];
-let capitalA = Js.String2.toUpperCase(a);
+let a = letters[0]; /* a == "a" */
+let capitalA = Js.String.toUpperCase(a);
 let k = letters[10]; /* Raises an exception! The 10th index doesn't exist. */
 ```
 
@@ -136,8 +136,8 @@ Because Belt avoids exceptions and returns `options` instead, this code behaves 
 ```reason
 open Belt;
 let letters = [|"a", "b", "c"|];
-let a = letters[0];
-let captialA = Js.String2.toUpperCase(a); /* Type error! This code will not compile. */
+let a = letters[0]; /* a == Some("a") */
+let captialA = Js.String.toUpperCase(a); /* Type error! This code will not compile. */
 let k = letters[10]; /* k == None */
 ```
 
@@ -157,12 +157,12 @@ let a = letters[0];
 /* Use a switch statement: */
 let capitalA =
   switch(a) {
-    | Some(a) => Some(Js.String2.toUpperCase(a))
+    | Some(a) => Some(Js.String.toUpperCase(a))
     | None => None
   };
   
 /* Alternatively, use the Option module: */
-let capitalA = a->Option.map(Js.String2.toUpperCase);
+let capitalA = a->Option.map(Js.String.toUpperCase);
 
 let k = letters[10]; /* k == None */
 ```

--- a/pages/apis/javascript/latest/belt.mdx
+++ b/pages/apis/javascript/latest/belt.mdx
@@ -120,6 +120,55 @@ For example, Belt has the following set modules:
 
 ## Implementation Details
 
+### Array access type safety
+
+One common confusion comes from the way Belt handles array access. It differs from than the default standard library's.
+
+```reason
+let letters = [|"a", "b", "c"|];
+let a = letters[0];
+let capitalA = Js.String2.toUpperCase(a);
+let k = letters[10]; /* Raises an exception! The 10th index doesn't exist. */
+```
+
+Because Belt avoids exceptions and returns `options` instead, this code behaves differently:
+
+```reason
+open Belt;
+let letters = [|"a", "b", "c"|];
+let a = letters[0];
+let captialA = Js.String2.toUpperCase(a); /* Type error! This code will not compile. */
+let k = letters[10]; /* k == None */
+```
+
+Although we've fixed the problem where `k` raises an exception, we now have a type error when trying to capitalize `a`. There are a few things going on here:
+
+- Reason transforms array index access to the function `Array.get`. So `letters[0]` is the same as `Array.get(letters, 0)`. 
+- This compiles to use whichever `Array` module is in scope. If you `open Belt`, then it uses `Belt.Array`.
+- `Belt.Array.get` returns values wrapped in options, so `letters[0] == Some("a")`. 
+
+Fortunately, this is easy to fix:
+
+```reason
+open Belt;
+let letters = [|"a, "b, "c"|];
+let a = letters[0];
+
+/* Use a switch statement: */
+let capitalA =
+  switch(a) {
+    | Some(a) => Some(Js.String2.toUpperCase(a))
+    | None => None
+  };
+  
+/* Alternatively, use the Option module: */
+let capitalA = a->Option.map(Js.String2.toUpperCase);
+
+let k = letters[10]; /* k == None */
+```
+
+With that little bit of tweaking, our code now compiles successfully and is 100% type safe!
+
 ### A special encoding for collection safety
 
 When we create a collection library for a custom data type we need a way to

--- a/pages/apis/javascript/latest/belt.mdx
+++ b/pages/apis/javascript/latest/belt.mdx
@@ -149,7 +149,7 @@ Although we've fixed the problem where `k` raises an exception, we now have a ty
 
 Fortunately, this is easy to fix:
 
-```reason
+```reason example
 open Belt;
 let letters = [|"a, "b, "c"|];
 let a = letters[0];

--- a/pages/apis/javascript/latest/belt.mdx
+++ b/pages/apis/javascript/latest/belt.mdx
@@ -120,7 +120,7 @@ For example, Belt has the following set modules:
 
 ## Implementation Details
 
-### Array access type safety
+### Array access runtime safety
 
 One common confusion comes from the way Belt handles array access. It differs from than the default standard library's.
 

--- a/pages/apis/javascript/latest/belt/array.mdx
+++ b/pages/apis/javascript/latest/belt/array.mdx
@@ -6,7 +6,7 @@ Utililites for `Array` functions.
 
 </Intro>
 
-## Note about index syntax
+### Note about index syntax
 
 Code like `arr[0]` does *not* compile to JavaScript `arr[0]`. Reason transforms the `[]` index syntax into a function: `Array.get(arr, 0)`. By default, this uses the default standard library's `Array.get` function, which may raise an exception if the index isn't found. If you `open Belt`, it will use the `Belt.Array.get` function which returns options instead of raising exceptions. [See this for more information](../belt.mdx#array-access-runtime-safety).
 

--- a/pages/apis/javascript/latest/belt/array.mdx
+++ b/pages/apis/javascript/latest/belt/array.mdx
@@ -6,6 +6,10 @@ Utililites for `Array` functions.
 
 </Intro>
 
+## Note about index syntax
+
+Code like `arr[0]` does *not* compile to JavaScript `arr[0]`. Reason transforms the `[]` index syntax into a function: `Array.get(arr, 0)`. By default, this uses the default standard library's `Array.get` function, which may raise an exception if the index isn't found. If you `open Belt`, it will use the `Belt.Array.get` function which returns options instead of raising exceptions. [See this for more information](../belt.mdx#array-access-runtime-safety).
+
 ## length
 
 ```re sig

--- a/pages/docs/manual/latest/list-and-array.mdx
+++ b/pages/docs/manual/latest/list-and-array.mdx
@@ -89,7 +89,7 @@ myArray[0] = "hey";
 /* now [|"hey", "world", "how are you"|] */
 ```
 
-The above array access/update is just syntax sugar for `Array.get`/`Array.set`.
+The above array access/update is syntax sugar for `Array.get`/`Array.set`. If you're compiling to JavaScript, note that code like `myArray[0]` does *not* compile to JavaScript `myArray[0]`, but rather `Array.get(myArray, 0)`. [See this for more information](../../../apis/javascript/latest/belt.mdx#array-access-runtime-safety).
 
 ### Tips & Tricks
 


### PR DESCRIPTION
This adds a few paragraphs about how array access is handled by Belt. This seems to be a common source of confusion, and I haven’t seen it mentioned anywhere else in the docs.

I wasn’t sure where the best location for this would be, so I put it in the “implementation details” page.