### PR TITLE
Add MDN references to String and String2.

### DIFF
--- a/components/Text.gen.js
+++ b/components/Text.gen.js
@@ -1,7 +1,0 @@
-/* Untyped file generated from Text.re by genType. */
-
-import * as TextBS from './Text.bs';
-
-export const Introduction_make = TextBS.Introduction.make;
-
-export const Introduction = TextBS.Introduction

--- a/pages/apis/javascript/latest/js/string-2.mdx
+++ b/pages/apis/javascript/latest/js/string-2.mdx
@@ -406,12 +406,11 @@ The function receives as its parameters the matched string, the offset at which 
 ```re example
 let str = "beautiful vowels";
 let re = [%re "/[aeiou]/g"];
-let matchFn = (matchPart, offset, wholeString) =>
+let matchFn = (matchPart, _offset, _wholeString) =>
   Js.String2.toUpperCase(matchPart);
 
-let replaced = Js.String2.unsafeReplaceBy0(str, re, matchFn);
-
-Js.log(replaced); /* prints "bEAUtifUl vOwEls" */
+Js.String2.unsafeReplaceBy0(str, re, matchFn)
+  == "bEAUtIfUl vOwEls";
 ```
 
 ## unsafeReplaceBy1
@@ -426,12 +425,11 @@ The function receives as its parameters the matched string, the captured string,
 ```re example
 let str = "increment 23";
 let re = [%re "/increment (\\d+)/g"];
-let matchFn = (matchPart, p1, offset, wholeString) =>
+let matchFn = (_matchPart, p1, _offset, wholeString) =>
   wholeString ++ " is " ++ string_of_int(int_of_string(p1) + 1);
 
-let replaced = Js.String2.unsafeReplaceBy1(str, re, matchFn);
-
-Js.log(replaced); /* prints "increment 23 is 24" */
+Js.String2.unsafeReplaceBy1(str, re, matchFn)
+  == "increment 23 is 24";
 ```
 
 ## unsafeReplaceBy2
@@ -449,9 +447,7 @@ let re = [%re "/(\\d+) times (\\d+)/"];
 let matchFn = (matchPart, p1, p2, offset, wholeString) =>
   string_of_int(int_of_string(p1) * int_of_string(p2));
 
-let replaced = Js.String2.unsafeReplaceBy2(str, re, matchFn);
-
-Js.log(replaced); /* prints "42" */
+Js.String2.unsafeReplaceBy2(str, re, matchFn) == "42";
 ```
 
 ## unsafeReplaceBy3
@@ -553,10 +549,8 @@ let splitByRe: (t, Js_re.t) => array(option(t));
 `splitByRe(str, regex)` splits the given `str` at every occurrence of `regex` and returns an array of the resulting substrings. See [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.
 
 ```re example
-Js.log(
-  Js.String2.splitByRe("art; bed , cog ;dad", [%re "/\\s*[,;]\\s*/"])
-  == [|Some("art"), Some("bed"), Some("cog"), Some("dad")|],
-);
+Js.String2.splitByRe("art; bed , cog ;dad", [%re "/\\s*[,;]\\s*/"])
+  == [|Some("art"), Some("bed"), Some("cog"), Some("dad")|];
 ```
 
 ## splitByReAtMost
@@ -569,18 +563,14 @@ let splitByReAtMost: (t, Js_re.t, ~limit: int) => array(option(t));
 If `n` is negative or greater than the number of substrings, the array will contain all the substrings. See [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.
 
 ```re example
-Js.log(
-  Js.String2.splitByReAtMost("one: two: three: four", [%re "/\\s*:\\s*/"], ~limit=3)
-  == [|Some("one"), Some("two"), Some("three")|],
-);
-Js.log(
-  Js.String2.splitByReAtMost("one: two: three: four", [%re "/\\s*:\\s*/"], ~limit=0)
-  == [||],
-);
-Js.log(
-  Js.String2.splitByReAtMost("one: two: three: four", [%re "/\\s*:\\s*/"], ~limit=8)
-  == [|Some("one"), Some("two"), Some("three"), Some("four")|],
-);
+Js.String2.splitByReAtMost("one: two: three: four", [%re "/\\s*:\\s*/"], ~limit=3)
+  == [|Some("one"), Some("two"), Some("three")|];
+
+Js.String2.splitByReAtMost("one: two: three: four", [%re "/\\s*:\\s*/"], ~limit=0)
+  == [||];
+
+Js.String2.splitByReAtMost("one: two: three: four", [%re "/\\s*:\\s*/"], ~limit=8)
+  == [|Some("one"), Some("two"), Some("three"), Some("four")|];
 ```
 
 ## startsWith

--- a/pages/apis/javascript/latest/js/string-2.mdx
+++ b/pages/apis/javascript/latest/js/string-2.mdx
@@ -21,8 +21,8 @@ let make: 'a => t;
 `make(value)` converts the given value to a `string`.
 
 ```re example
-Js.log(Js.String2.make(3.5) == "3.5");
-Js.log(Js.String2.make([|1,2,3|]) == "1,2,3");
+Js.String2.make(3.5) == "3.5";
+Js.String2.make([|1,2,3|]) == "1,2,3";
 ```
 
 ## fromCharCode
@@ -32,13 +32,13 @@ let fromCharCode: int => t;
 ```
 
 `fromCharCode(n)` creates a `string` containing the character corresponding to that number; `n` ranges from 0 to 65535.
-If out of range, the lower 16 bits of the value are used. Thus, `fromCharCode(0x1F63A)` gives the same result as `fromCharCode(0xF63A)`.
+If out of range, the lower 16 bits of the value are used. Thus, `fromCharCode(0x1F63A)` gives the same result as `fromCharCode(0xF63A)`. See [`String.fromCharCode`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode) on MDN.
 
 ```re sig
-Js.log(Js.String2.fromCharCode(65) == "A");
-Js.log(Js.String2.fromCharCode(0x3c8) == {js|ψ|js});
-Js.log(Js.String2.fromCharCode(0xd55c) == {js|한|js});
-Js.log(Js.String2.fromCharCode(-64568) == {js|ψ|js});
+Js.String2.fromCharCode(65) == "A";
+Js.String2.fromCharCode(0x3c8) == {js|ψ|js};
+Js.String2.fromCharCode(0xd55c) == {js|한|js};
+Js.String2.fromCharCode(-64568) == {js|ψ|js};
 ```
 
 ## fromCharCodeMany
@@ -47,7 +47,7 @@ Js.log(Js.String2.fromCharCode(-64568) == {js|ψ|js});
 let fromCharCodeMany: array(int) => t;
 ```
 
-`fromCharCodeMany([|n1;n2;n3|])` creates a `string` from the characters corresponding to the given numbers, using the same rules as `fromCharCode`.
+`fromCharCodeMany([|n1;n2;n3|])` creates a `string` from the characters corresponding to the given numbers, using the same rules as `fromCharCode`. See [`String.fromCharCode`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode) on MDN.
 
 ## fromCodePoint
 
@@ -57,13 +57,13 @@ let fromCodePoint: int => t;
 
 `fromCodePoint(n)` creates a `string` containing the character corresponding to that numeric code point. 
 If the number is not a valid code point, it raises `RangeError`. 
-Thus, `fromCodePoint(0x1F63A)` will produce a correct value, unlike `fromCharCode(0x1F63A)`, and `fromCodePoint(-5)` will raise a `RangeError`.
+Thus, `fromCodePoint(0x1F63A)` will produce a correct value, unlike `fromCharCode(0x1F63A)`, and `fromCodePoint(-5)` will raise a `RangeError`. See [`String.fromCodePoint`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint) on MDN.
  
 ```re example
-Js.log(Js.String2.fromCodePoint(65) == "A");
-Js.log(Js.String2.fromCodePoint(0x3c8) == {js|ψ|js});
-Js.log(Js.String2.fromCodePoint(0xd55c) == {js|한|js});
-Js.log(Js.String2.fromCodePoint(0x1f63a) == {js|😺|js});
+Js.String2.fromCodePoint(65) == "A";
+Js.String2.fromCodePoint(0x3c8) == {js|ψ|js};
+Js.String2.fromCodePoint(0xd55c) == {js|한|js};
+Js.String2.fromCodePoint(0x1f63a) == {js|😺|js};
 ```
 
 ## fromCodePointMany
@@ -72,10 +72,10 @@ Js.log(Js.String2.fromCodePoint(0x1f63a) == {js|😺|js});
 let fromCodePointMany: array(int) => t;
 ```
 
-`fromCodePointMany([|n1;n2;n3|])` creates a `string` from the characters corresponding to the given code point numbers, using the same rules as `fromCodePoint`.
+`fromCodePointMany([|n1;n2;n3|])` creates a `string` from the characters corresponding to the given code point numbers, using the same rules as `fromCodePoint`. See [`String.fromCodePoint`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint) on MDN.
 
 ```re example
-Js.log(Js.String2.fromCodePointMany([|0xd55c, 0xae00, 0x1f63a|]) == {js|한글😺|js});
+Js.String2.fromCodePointMany([|0xd55c, 0xae00, 0x1f63a|]) == {js|한글😺|js};
 ```
 
 ## length
@@ -84,10 +84,10 @@ Js.log(Js.String2.fromCodePointMany([|0xd55c, 0xae00, 0x1f63a|]) == {js|한글�
 let length: t => int;
 ```
 
-`length(s)` returns the length of the given `string`.
+`length(s)` returns the length of the given `string`. See [`String.length`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length) on MDN.
 
 ```re example
-Js.log(Js.String2.length("abcd") == 4);
+Js.String2.length("abcd") == 4;
 ```
 
 ## get
@@ -100,9 +100,9 @@ let get: (t, int) => t;
 If `n` is out of range, this function returns `undefined`,so at some point this function may be modified to return `option(string)`.
 
 ```re example
-Js.log(Js.String2.get("Reason", 0) == "R");
-Js.log(Js.String2.get("Reason", 4) == "o");
-Js.log(Js.String2.get({js|Rẽasöń|js}, 5) == {js|ń|js});
+Js.String2.get("Reason", 0) == "R";
+Js.String2.get("Reason", 4) == "o";
+Js.String2.get({js|Rẽasöń|js}, 5) == {js|ń|js};
 ```
 
 ## charAt
@@ -113,12 +113,12 @@ let charAt: (t, int) => t;
 
 `charAt(s, n)` gets the character at index `n` within string `s`. 
 If `n` is negative or greater than the length of `s`, it returns the empty string.
-If the string contains characters outside the range \u0000-\uffff, it will return the first 16-bit value at that position in the string.
+If the string contains characters outside the range \u0000-\uffff, it will return the first 16-bit value at that position in the string. See [`String.charAt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charAt) on MDN.
 
 ```re example
-Js.log(Js.String2.charAt("Reason", 0) == "R");
-Js.log(Js.String2.charAt("Reason", 12) == "");
-Js.log(Js.String2.charAt({js|Rẽasöń|js}, 5) == {js|ń|js});
+Js.String2.charAt("Reason", 0) == "R";
+Js.String2.charAt("Reason", 12) == "";
+Js.String2.charAt({js|Rẽasöń|js}, 5) == {js|ń|js};
 ```
 
 ## charCodeAt
@@ -128,11 +128,11 @@ let charCodeAt: (t, int) => float;
 ```
 
 `charCodeAt(s, n)` returns the character code at position `n` in string `s`; the result is in the range 0-65535, unlke `codePointAt`, so it will not work correctly for characters with code points greater than or equal to 0x10000. 
-The return type is `float` because this function returns NaN if `n` is less than zero or greater than the length of the string.
+The return type is `float` because this function returns NaN if `n` is less than zero or greater than the length of the string. See [`String.charCodeAt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt) on MDN.
 
 ```re example
-Js.log(Js.String2.charCodeAt({js|😺|js}, 0) == 0xd83d->float_of_int);
-Js.log(Js.String2.codePointAt({js|😺|js}, 0) == Some(0x1f63a));
+Js.String2.charCodeAt({js|😺|js}, 0) == 0xd83d->float_of_int;
+Js.String2.codePointAt({js|😺|js}, 0) == Some(0x1f63a);
 ```
 
 ## codePointAt
@@ -143,11 +143,11 @@ let codePointAt: (t, int) => option(int);
 
 `codePointAt(s, n)` returns the code point at position `n` within string `s` as a `Some(value)`. 
 The return value handles code points greater than or equal to 0x10000.
-If there is no code point at the given position, the function returns `None`.
+If there is no code point at the given position, the function returns `None`. See [`String.codePointAt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/codePointAt) on MDN.
 
 ```re example
-Js.log(Js.String2.codePointAt({js|¿😺?|js}, 1) == Some(0x1f63a));
-Js.log(Js.String2.codePointAt("abc", 5) == None);
+Js.String2.codePointAt({js|¿😺?|js}, 1) == Some(0x1f63a);
+Js.String2.codePointAt("abc", 5) == None;
 ```
 
 ## concat
@@ -156,10 +156,10 @@ Js.log(Js.String2.codePointAt("abc", 5) == None);
 let concat: (t, t) => t;
 ```
 
-`concat(original, append)` returns a new `string` with `append` added after `original`.
+`concat(original, append)` returns a new `string` with `append` added after `original`. See [`String.concat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/concat) on MDN.
 
 ```re example
-Js.log(Js.String2.concat("cow", "bell") == "cowbell");
+Js.String2.concat("cow", "bell") == "cowbell";
 ```
 
 ## concatMany
@@ -168,10 +168,10 @@ Js.log(Js.String2.concat("cow", "bell") == "cowbell");
 let concatMany: (t, array(t)) => t;
 ```
 
-`concat(original, arr)` returns a new `string` consisting of each item of an array of strings added to the `original` string.
+`concat(original, arr)` returns a new `string` consisting of each item of an array of strings added to the `original` string. See [`String.concat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/concat) on MDN.
 
 ```re example
-Js.log(Js.String2.concatMany("1st", [|"2nd", "3rd", "4th"|]) == "1st2nd3rd4th");
+Js.String2.concatMany("1st", [|"2nd", "3rd", "4th"|]) == "1st2nd3rd4th";
 ```
 
 ## endsWith
@@ -180,11 +180,11 @@ Js.log(Js.String2.concatMany("1st", [|"2nd", "3rd", "4th"|]) == "1st2nd3rd4th");
 let endsWith: (t, t) => bool;
 ```
 
-ES2015: `endsWith(str, substr)` returns `true` if the `str` ends with `substr`, `false` otherwise.
+ES2015: `endsWith(str, substr)` returns `true` if the `str` ends with `substr`, `false` otherwise. See [`String.endsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith) on MDN.
 
 ```re example
-Js.log(Js.String2.endsWith("BuckleScript", "Script") == true);
-Js.log(Js.String2.endsWith("BuckleShoes", "Script") == false);
+Js.String2.endsWith("BuckleScript", "Script") == true;
+Js.String2.endsWith("BuckleShoes", "Script") == false;
 ```
 
 ## endsWithFrom
@@ -194,13 +194,13 @@ let endsWithFrom: (t, t, int) => bool;
 ```
 
 `endsWithFrom(str, ending, len)` returns `true` if the first len characters of `str` end with `ending`, `false` otherwise.
-If `len` is greater than or equal to the length of `str`, then it works like `endsWith`. (Honestly, this should have been named endsWithAt, but oh well.)
+If `len` is greater than or equal to the length of `str`, then it works like `endsWith`. (Honestly, this should have been named endsWithAt, but oh well.) See [`String.endsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith) on MDN.
 
 ```re example
-Js.log(Js.String2.endsWithFrom("abcd", "cd", 4) == true);
-Js.log(Js.String2.endsWithFrom("abcde", "cd", 3) == false);
-Js.log(Js.String2.endsWithFrom("abcde", "cde", 99) == true);
-Js.log(Js.String2.endsWithFrom("example.dat", "ple", 7) == true);
+Js.String2.endsWithFrom("abcd", "cd", 4) == true;
+Js.String2.endsWithFrom("abcde", "cd", 3) == false;
+Js.String2.endsWithFrom("abcde", "cde", 99) == true;
+Js.String2.endsWithFrom("example.dat", "ple", 7) == true;
 ```
 
 ## includes
@@ -209,13 +209,13 @@ Js.log(Js.String2.endsWithFrom("example.dat", "ple", 7) == true);
 let includes: (t, t) => bool;
 ```
 
-ES2015: `includes(str, searchValue)` returns `true` if `searchValue` is found anywhere within `str`, false otherwise.
+ES2015: `includes(str, searchValue)` returns `true` if `searchValue` is found anywhere within `str`, false otherwise. See [`String.includes`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes) on MDN.
 
 ```re example
-Js.log(Js.String2.includes("programmer", "gram") == true);
-Js.log(Js.String2.includes("programmer", "er") == true);
-Js.log(Js.String2.includes("programmer", "pro") == true);
-Js.log(Js.String2.includes("programmer.dat", "xyz") == false);
+Js.String2.includes("programmer", "gram") == true;
+Js.String2.includes("programmer", "er") == true;
+Js.String2.includes("programmer", "pro") == true;
+Js.String2.includes("programmer.dat", "xyz") == false;
 ```
 
 ## includesFrom
@@ -224,12 +224,12 @@ Js.log(Js.String2.includes("programmer.dat", "xyz") == false);
 let includesFrom: (t, t, int) => bool;
 ```
 
-ES2015: `includes(str, searchValue start)` returns `true` if `searchValue` is found anywhere within `str` starting at character number `start` (where 0 is the first character), `false` otherwise.
+ES2015: `includes(str, searchValue start)` returns `true` if `searchValue` is found anywhere within `str` starting at character number `start` (where 0 is the first character), `false` otherwise. See [`String.includes`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes) on MDN.
 
 ```re example
-Js.log(Js.String2.includesFrom("programmer", "gram", 1) == true);
-Js.log(Js.String2.includesFrom("programmer", "gram", 4) == false);
-Js.log(Js.String2.includesFrom({js|대한민국|js}, {js|한|js}, 1) == true);
+Js.String2.includesFrom("programmer", "gram", 1) == true;
+Js.String2.includesFrom("programmer", "gram", 4) == false;
+Js.String2.includesFrom({js|대한민국|js}, {js|한|js}, 1) == true;
 ```
 
 ## indexOf
@@ -238,13 +238,13 @@ Js.log(Js.String2.includesFrom({js|대한민국|js}, {js|한|js}, 1) == true);
 let indexOf: (t, t) => int;
 ```
 
-ES2015: `indexOf(str, searchValue)` returns the position at which `searchValue` was first found within `str`, or -1 if `searchValue` is not in `str`.
+ES2015: `indexOf(str, searchValue)` returns the position at which `searchValue` was first found within `str`, or -1 if `searchValue` is not in `str`. See [`String.indexOf`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf) on MDN.
 
 ```re example
-Js.log(Js.String2.indexOf("bookseller", "ok") == 2);
-Js.log(Js.String2.indexOf("bookseller", "sell") == 4);
-Js.log(Js.String2.indexOf("beekeeper", "ee") == 1);
-Js.log(Js.String2.indexOf("bookseller", "xyz") == -1);
+Js.String2.indexOf("bookseller", "ok") == 2;
+Js.String2.indexOf("bookseller", "sell") == 4;
+Js.String2.indexOf("beekeeper", "ee") == 1;
+Js.String2.indexOf("bookseller", "xyz") == -1;
 ```
 
 ## indexOfFrom
@@ -253,12 +253,12 @@ Js.log(Js.String2.indexOf("bookseller", "xyz") == -1);
 let indexOfFrom: (t, t, int) => int;
 ```
 `indexOfFrom(str, searchValue, start)` returns the position at which `searchValue` was found within `str` starting at character position `start`, or -1 if `searchValue` is not found in that portion of `str`.
-The return value is relative to the beginning of the string, no matter where the search started from.
+The return value is relative to the beginning of the string, no matter where the search started from. See [`String.indexOf`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf) on MDN.
 
 ```re example
-Js.log(Js.String2.indexOfFrom("bookseller", "ok", 1) == 2);
-Js.log(Js.String2.indexOfFrom("bookseller", "sell", 2) == 4);
-Js.log(Js.String2.indexOfFrom("bookseller", "sell", 5) == -1);
+Js.String2.indexOfFrom("bookseller", "ok", 1) == 2;
+Js.String2.indexOfFrom("bookseller", "sell", 2) == 4;
+Js.String2.indexOfFrom("bookseller", "sell", 5) == -1;
 ```
 
 ## lastIndexOf
@@ -268,12 +268,12 @@ let lastIndexOf: (t, t) => int;
 ```
 
 `lastIndexOf(str, searchValue)` returns the position of the last occurrence of `searchValue` within `str`, searching backwards from the end of the string.
-Returns -1 if `searchValue` is not in `str`. The return value is always relative to the beginning of the string.
+Returns -1 if `searchValue` is not in `str`. The return value is always relative to the beginning of the string. See [`String.lastIndexOf`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/lastIndexOf) on MDN.
 
 ```re example
-Js.log(Js.String2.lastIndexOf("bookseller", "ok") == 2);
-Js.log(Js.String2.lastIndexOf("beekeeper", "ee") == 4);
-Js.log(Js.String2.lastIndexOf("abcdefg", "xyz") == -1);
+Js.String2.lastIndexOf("bookseller", "ok") == 2;
+Js.String2.lastIndexOf("beekeeper", "ee") == 4;
+Js.String2.lastIndexOf("abcdefg", "xyz") == -1;
 ```
 
 ## lastIndexOfFrom
@@ -283,13 +283,13 @@ let lastIndexOfFrom: (t, t, int) => int;
 ```
 
 `lastIndexOfFrom(str, searchValue, start)` returns the position of the last occurrence of `searchValue` within `str`, searching backwards from the given start position.
-Returns -1 if `searchValue` is not in `str`. The return value is always relative to the beginning of the string.
+Returns -1 if `searchValue` is not in `str`. The return value is always relative to the beginning of the string. See [`String.lastIndexOf`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/lastIndexOf) on MDN.
 
 ```re example
-Js.log(Js.String2.lastIndexOfFrom("bookseller", "ok", 6) == 2);
-Js.log(Js.String2.lastIndexOfFrom("beekeeper", "ee", 8) == 4);
-Js.log(Js.String2.lastIndexOfFrom("beekeeper", "ee", 3) == 1);
-Js.log(Js.String2.lastIndexOfFrom("abcdefg", "xyz", 4) == -1);
+Js.String2.lastIndexOfFrom("bookseller", "ok", 6) == 2;
+Js.String2.lastIndexOfFrom("beekeeper", "ee", 8) == 4;
+Js.String2.lastIndexOfFrom("beekeeper", "ee", 3) == 1;
+Js.String2.lastIndexOfFrom("abcdefg", "xyz", 4) == -1;
 ```
 
 ## localeCompare
@@ -303,11 +303,13 @@ let localeCompare: (t, t) => float;
 - zero if reference and comparison have the same sort order
 - a positive value if reference comes after comparison in sort order
 
+See [`String.localeCompare`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare) on MDN.
+
 ```re example
-Js.log(Js.String2.localeCompare("zebra", "ant") > 0.0);
-Js.log(Js.String2.localeCompare("ant", "zebra") < 0.0);
-Js.log(Js.String2.localeCompare("cat", "cat") == 0.0);
-Js.log(Js.String2.localeCompare("CAT", "cat") > 0.0);
+Js.String2.localeCompare("zebra", "ant") > 0.0;
+Js.String2.localeCompare("ant", "zebra") < 0.0;
+Js.String2.localeCompare("cat", "cat") == 0.0;
+Js.String2.localeCompare("CAT", "cat") > 0.0;
 ```
 
 ## match
@@ -319,13 +321,13 @@ let match: (t, Js_re.t) => option(array(t));
 `match(str, regexp)` matches a `string` against the given `regexp`. If there is no match, it returns `None`. For regular expressions without the g modifier, if there is a match, the return value is `Some(array)` where the array contains:
 - The entire matched string
 - Any capture groups if the regexp had parentheses
-For regular expressions with the g modifier, a matched expression returns `Some(array)` with all the matched substrings and no capture groups.
+For regular expressions with the g modifier, a matched expression returns `Some(array)` with all the matched substrings and no capture groups. See [`String.match`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) on MDN.
 
 ```re example
-Js.log(Js.String2.match("The better bats", [%re "/b[aeiou]t/"]) == Some([|"bet"|]));
-Js.log(Js.String2.match("The better bats", [%re "/b[aeiou]t/g"]) == Some([|"bet", "bat"|]));
-Js.log(Js.String2.match("Today is 2018-04-05.", [%re "/(\\d+)-(\\d+)-(\\d+)/"]) == Some([|"2018-04-05", "2018", "04", "05"|]));
-Js.log(Js.String2.match("The large container.", [%re "/b[aeiou]g/"]) == None);
+Js.String2.match("The better bats", [%re "/b[aeiou]t/"]) == Some([|"bet"|]);
+Js.String2.match("The better bats", [%re "/b[aeiou]t/g"]) == Some([|"bet", "bat"|]);
+Js.String2.match("Today is 2018-04-05.", [%re "/(\\d+)-(\\d+)-(\\d+)/"]) == Some([|"2018-04-05", "2018", "04", "05"|]);
+Js.String2.match("The large container.", [%re "/b[aeiou]g/"]) == None;
 ```
 
 ## normalize
@@ -336,8 +338,7 @@ let normalize: t => t;
 
 `normalize(str)` returns the normalized Unicode string using Normalization Form Canonical (NFC) Composition.
 Consider the character ã, which can be represented as the single codepoint \u00e3 or the combination of a lower case letter A \u0061 and a combining tilde \u0303.
-Normalization ensures that both can be stored in an equivalent binary representation.
-See also Unicode technical report for details.
+Normalization ensures that both can be stored in an equivalent binary representation. See [`String.normalize`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize) on MDN. See also [Unicode technical report #15](https://unicode.org/reports/tr15/) for details. 
 
 ## normalizeByForm
 
@@ -351,7 +352,7 @@ ES2015: `normalize(str, form)` returns the normalized Unicode string using the s
 - "NFKC" — Normalization Form Compatibility Composition.
 - "NFKD" — Normalization Form Compatibility Decomposition.
 
-See also Unicode technical report for details.
+See [`String.normalize`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize) on MDN. See also [Unicode technical report #15](https://unicode.org/reports/tr15/) for details..
 
 ## repeat
 
@@ -359,11 +360,11 @@ See also Unicode technical report for details.
 let repeat: (t, int) => t;
 ```
 
-`repeat(str, n)` returns a `string` that consists of `n` repetitions of `str`. Raises `RangeError` if `n` is negative.
+`repeat(str, n)` returns a `string` that consists of `n` repetitions of `str`. Raises `RangeError` if `n` is negative. See [`String.repeat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat) on MDN.
 
 ```re example
-Js.log(Js.String2.repeat("ha", 3) == "hahaha");
-Js.log(Js.String2.repeat("empty", 0) == "");
+Js.String2.repeat("ha", 3) == "hahaha";
+Js.String2.repeat("empty", 0) == "";
 ```
 
 ## replace
@@ -373,11 +374,11 @@ let replace: (t, t, t) => t;
 ```
 
 ES2015: `replace(str, substr, newSubstr)` returns a new `string` which is identical to `str` except with the first matching instance of `substr` replaced by `newSubstr`.
-`substr` is treated as a verbatim string to match, not a regular expression.
+`substr` is treated as a verbatim string to match, not a regular expression. See [`String.replace`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) on MDN.
 
 ```re example
-Js.log(Js.String2.replace("old string", "old", "new") == "new string");
-Js.log(Js.String2.replace("the cat and the dog", "the", "this") == "this cat and the dog");
+Js.String2.replace("old string", "old", "new") == "new string";
+Js.String2.replace("the cat and the dog", "the", "this") == "this cat and the dog";
 ```
 
 ## replaceByRe
@@ -386,11 +387,11 @@ Js.log(Js.String2.replace("the cat and the dog", "the", "this") == "this cat and
 let replaceByRe: (t, Js_re.t, t) => t;
 ```
 
-`replaceByRe(str, regex, replacement)` returns a new `string` where occurrences matching regex have been replaced by `replacement`.
+`replaceByRe(str, regex, replacement)` returns a new `string` where occurrences matching regex have been replaced by `replacement`. See [`String.replace`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) on MDN.
 
 ```re example
-Js.log(Js.String2.replaceByRe("vowels be gone", [%re "/[aeiou]/g"], "x") == "vxwxls bx gxnx");
-Js.log(Js.String2.replaceByRe("Juan Fulano", [%re "/(\\w+) (\\w+)/"], "$2, $1") == "Fulano, Juan");
+Js.String2.replaceByRe("vowels be gone", [%re "/[aeiou]/g"], "x") == "vxwxls bx gxnx";
+Js.String2.replaceByRe("Juan Fulano", [%re "/(\\w+) (\\w+)/"], "$2, $1") == "Fulano, Juan";
 ```
 
 ## unsafeReplaceBy0
@@ -400,7 +401,7 @@ let unsafeReplaceBy0: (t, Js_re.t, (t, int, t) => t) => t;
 ```
 
 Returns a new `string` with some or all matches of a pattern with no capturing parentheses replaced by the value returned from the given function.
-The function receives as its parameters the matched string, the offset at which the match begins, and the whole string being matched.
+The function receives as its parameters the matched string, the offset at which the match begins, and the whole string being matched. See [`String.replace`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) on MDN.
 
 ```re example
 let str = "beautiful vowels";
@@ -420,7 +421,7 @@ let unsafeReplaceBy1: (t, Js_re.t, (t, t, int, t) => t) => t;
 ```
 
 Returns a new `string` with some or all matches of a pattern with one set of capturing parentheses replaced by the value returned from the given function.
-The function receives as its parameters the matched string, the captured string, the offset at which the match begins, and the whole string being matched.
+The function receives as its parameters the matched string, the captured string, the offset at which the match begins, and the whole string being matched. See [`String.replace`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) on MDN.
 
 ```re example
 let str = "increment 23";
@@ -440,7 +441,7 @@ let unsafeReplaceBy2: (t, Js_re.t, (t, t, t, int, t) => t) => t;
 ```
 
 Returns a new `string` with some or all matches of a pattern with two sets of capturing parentheses replaced by the value returned from the given function.
-The function receives as its parameters the matched string, the captured strings, the offset at which the match begins, and the whole string being matched.
+The function receives as its parameters the matched string, the captured strings, the offset at which the match begins, and the whole string being matched. See [`String.replace`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) on MDN.
 
 ```re example
 let str = "7 times 6";
@@ -460,7 +461,7 @@ let unsafeReplaceBy3: (t, Js_re.t, (t, t, t, t, int, t) => t) => t;
 ```
 
 Returns a new `string` with some or all matches of a pattern with three sets of capturing parentheses replaced by the value returned from the given function.
-The function receives as its parameters the matched string, the captured strings, the offset at which the match begins, and the whole string being matched.
+The function receives as its parameters the matched string, the captured strings, the offset at which the match begins, and the whole string being matched. See [`String.replace`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) on MDN.
 
 ## search
 
@@ -468,11 +469,11 @@ The function receives as its parameters the matched string, the captured strings
 let search: (t, Js_re.t) => int;
 ```
 
-`search(str, regexp)` returns the starting position of the first match of `regexp` in the given `str`, or -1 if there is no match.
+`search(str, regexp)` returns the starting position of the first match of `regexp` in the given `str`, or -1 if there is no match. See [`String.search`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/search) on MDN.
 
 ```re example
-Js.log(Js.String2.search("testing 1 2 3", [%re "/\\d+/"]) == 8);
-Js.log(Js.String2.search("no numbers", [%re "/\\d+/"]) == -1);
+Js.String2.search("testing 1 2 3", [%re "/\\d+/"]) == 8;
+Js.String2.search("no numbers", [%re "/\\d+/"]) == -1;
 ```
 
 ## slice
@@ -486,11 +487,13 @@ let slice: (t, ~from: int, ~to_: int) => t;
 - If `n2` is greater than the length of `str`, then it is treated as `length(str)`.
 - If `n1` is greater than `n2`, slice returns the empty string.
 
+See [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.
+
 ```re example
-Js.log(Js.String2.slice("abcdefg", ~from=2, ~to_=5) == "cde");
-Js.log(Js.String2.slice("abcdefg", ~from=2, ~to_=9) == "cdefg");
-Js.log(Js.String2.slice("abcdefg", ~from=(-4), ~to_=(-2)) == "de");
-Js.log(Js.String2.slice("abcdefg", ~from=5, ~to_=1) == "");
+Js.String2.slice("abcdefg", ~from=2, ~to_=5) == "cde";
+Js.String2.slice("abcdefg", ~from=2, ~to_=9) == "cdefg";
+Js.String2.slice("abcdefg", ~from=(-4), ~to_=(-2)) == "de";
+Js.String2.slice("abcdefg", ~from=5, ~to_=1) == "";
 ```
 
 ## sliceToEnd
@@ -503,10 +506,12 @@ let sliceToEnd: (t, ~from: int) => t;
 - If `n` is negative, then it is evaluated as `length(str - n)`.
 - If `n` is greater than the length of `str`, then sliceToEnd returns the empty string.
 
+See [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.
+
 ```re example
-Js.log(Js.String2.sliceToEnd("abcdefg", ~from=4) == "efg");
-Js.log(Js.String2.sliceToEnd("abcdefg", ~from=(-2)) == "fg");
-Js.log(Js.String2.sliceToEnd("abcdefg", ~from=7) == "");
+Js.String2.sliceToEnd("abcdefg", ~from=4) == "efg";
+Js.String2.sliceToEnd("abcdefg", ~from=(-2)) == "fg";
+Js.String2.sliceToEnd("abcdefg", ~from=7) == "";
 ```
 
 ## split
@@ -515,13 +520,13 @@ Js.log(Js.String2.sliceToEnd("abcdefg", ~from=7) == "");
 let split: (t, t) => array(t);
 ```
 
-`split(str, delimiter)` splits the given `str` at every occurrence of `delimiter` and returns an array of the resulting substrings.
+`split(str, delimiter)` splits the given `str` at every occurrence of `delimiter` and returns an array of the resulting substrings. See [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.
 
 ```re example
-Js.log(Js.String2.split("2018-01-02", "-") == [|"2018", "01", "02"|]);
-Js.log(Js.String2.split("a,b,,c", ",") == [|"a", "b", "", "c"|]);
-Js.log(Js.String2.split("good::bad as great::awful", "::") == [|"good", "bad as great", "awful"|]);
-Js.log(Js.String2.split("has-no-delimiter", ";") == [|"has-no-delimiter"|]);
+Js.String2.split("2018-01-02", "-") == [|"2018", "01", "02"|];
+Js.String2.split("a,b,,c", ",") == [|"a", "b", "", "c"|];
+Js.String2.split("good::bad as great::awful", "::") == [|"good", "bad as great", "awful"|];
+Js.String2.split("has-no-delimiter", ";") == [|"has-no-delimiter"|];
 ```
 
 ## splitAtMost
@@ -531,12 +536,12 @@ let splitAtMost: (t, t, ~limit: int) => array(t);
 ```
 
 `splitAtMost(str, delimiter, ~limit:n)` splits the given `str` at every occurrence of `delimiter` and returns an array of the first `n` resulting substrings.
-If `n` is negative or greater than the number of substrings, the array will contain all the substrings.
+If `n` is negative or greater than the number of substrings, the array will contain all the substrings. See [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.
 
 ```re example
-Js.log(Js.String2.splitAtMost("ant/bee/cat/dog/elk", "/", ~limit=3) == [|"ant", "bee", "cat"|]);
-Js.log(Js.String2.splitAtMost("ant/bee/cat/dog/elk", "/", ~limit=0) == [||]);
-Js.log(Js.String2.splitAtMost("ant/bee/cat/dog/elk", "/", ~limit=9) == [|"ant", "bee", "cat", "dog", "elk"|]);
+Js.String2.splitAtMost("ant/bee/cat/dog/elk", "/", ~limit=3) == [|"ant", "bee", "cat"|];
+Js.String2.splitAtMost("ant/bee/cat/dog/elk", "/", ~limit=0) == [||];
+Js.String2.splitAtMost("ant/bee/cat/dog/elk", "/", ~limit=9) == [|"ant", "bee", "cat", "dog", "elk"|];
 ```
 
 ## splitByRe
@@ -545,7 +550,7 @@ Js.log(Js.String2.splitAtMost("ant/bee/cat/dog/elk", "/", ~limit=9) == [|"ant", 
 let splitByRe: (t, Js_re.t) => array(option(t));
 ```
 
-`splitByRe(str, regex)` splits the given `str` at every occurrence of `regex` and returns an array of the resulting substrings.
+`splitByRe(str, regex)` splits the given `str` at every occurrence of `regex` and returns an array of the resulting substrings. See [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.
 
 ```re example
 Js.log(
@@ -561,7 +566,7 @@ let splitByReAtMost: (t, Js_re.t, ~limit: int) => array(option(t));
 ```
 
 `splitByReAtMost(str, regex, ~limit:n)` splits the given `str` at every occurrence of `regex` and returns an array of the first `n` resulting substrings.
-If `n` is negative or greater than the number of substrings, the array will contain all the substrings.
+If `n` is negative or greater than the number of substrings, the array will contain all the substrings. See [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.
 
 ```re example
 Js.log(
@@ -584,12 +589,12 @@ Js.log(
 let startsWith: (t, t) => bool;
 ```
 
-ES2015: `startsWith(str, substr)` returns `true` if the `str` starts with `substr`, `false` otherwise.
+ES2015: `startsWith(str, substr)` returns `true` if the `str` starts with `substr`, `false` otherwise. See [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.
 
 ```re example
-Js.log(Js.String2.startsWith("BuckleScript", "Buckle") == true);
-Js.log(Js.String2.startsWith("BuckleScript", "") == true);
-Js.log(Js.String2.startsWith("JavaScript", "Buckle") == false);
+Js.String2.startsWith("BuckleScript", "Buckle") == true;
+Js.String2.startsWith("BuckleScript", "") == true;
+Js.String2.startsWith("JavaScript", "Buckle") == false;
 ```
 
 ## startsWithFrom
@@ -599,12 +604,12 @@ let startsWithFrom: (t, t, int) => bool;
 ```
 
 ES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts with `substr` starting at position `n`, false otherwise.
-If `n` is negative, the search starts at the beginning of `str`.
+If `n` is negative, the search starts at the beginning of `str`. See [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.
 
 ```re example
-Js.log(Js.String2.startsWithFrom("BuckleScript", "kle", 3) == true);
-Js.log(Js.String2.startsWithFrom("BuckleScript", "", 3) == true);
-Js.log(Js.String2.startsWithFrom("JavaScript", "Buckle", 2) == false);
+Js.String2.startsWithFrom("BuckleScript", "kle", 3) == true;
+Js.String2.startsWithFrom("BuckleScript", "", 3) == true;
+Js.String2.startsWithFrom("JavaScript", "Buckle", 2) == false;
 ```
 
 ## substr
@@ -617,10 +622,12 @@ let substr: (t, ~from: int) => t;
 - If `n` is less than zero, the starting position is the length of `str - n`.
 - If `n` is greater than or equal to the length of `str`, returns the empty string.
 
+JavaScript’s `String.substr()` is a legacy function. When possible, use `substring()` instead. See [`String.substr`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) on MDN.
+
 ```re example
-Js.log(Js.String2.substr("abcdefghij", ~from=3) == "defghij");
-Js.log(Js.String2.substr("abcdefghij", ~from=(-3)) == "hij");
-Js.log(Js.String2.substr("abcdefghij", ~from=12) == "");
+Js.String2.substr("abcdefghij", ~from=3) == "defghij";
+Js.String2.substr("abcdefghij", ~from=(-3)) == "hij";
+Js.String2.substr("abcdefghij", ~from=12) == "";
 ```
 
 ## substrAtMost
@@ -634,10 +641,12 @@ let substrAtMost: (t, ~from: int, ~length: int) => t;
 - If `pos` is greater than or equal to the length of `str`, returns the empty string.
 - If `n` is less than or equal to zero, returns the empty string.
 
+JavaScript’s `String.substr()` is a legacy function. When possible, use `substring()` instead. See [`String.substr`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) on MDN.
+
 ```re example
-Js.log(Js.String2.substrAtMost("abcdefghij", ~from=3, ~length=4) == "defg");
-Js.log(Js.String2.substrAtMost("abcdefghij", ~from=(-3), ~length=4) == "hij");
-Js.log(Js.String2.substrAtMost("abcdefghij", ~from=12, ~length=2) == "");
+Js.String2.substrAtMost("abcdefghij", ~from=3, ~length=4) == "defg";
+Js.String2.substrAtMost("abcdefghij", ~from=(-3), ~length=4) == "hij";
+Js.String2.substrAtMost("abcdefghij", ~from=12, ~length=2) == "";
 ```
 
 ## substring
@@ -651,10 +660,12 @@ let substring: (t, ~from: int, ~to_: int) => t;
 - If `finish` is zero or negative, the empty string is returned.
 - If `start` is greater than `finish`, the `start` and `finish` points are swapped.
 
+See [`String.substring`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) on MDN.
+
 ```re example
-Js.log(Js.String2.substring("playground", ~from=3, ~to_=6) == "ygr");
-Js.log(Js.String2.substring("playground", ~from=6, ~to_=3) == "ygr");
-Js.log(Js.String2.substring("playground", ~from=4, ~to_=12) == "ground");
+Js.String2.substring("playground", ~from=3, ~to_=6) == "ygr";
+Js.String2.substring("playground", ~from=6, ~to_=3) == "ygr";
+Js.String2.substring("playground", ~from=4, ~to_=12) == "ground";
 ```
 
 ## substringToEnd
@@ -667,10 +678,12 @@ let substringToEnd: (t, ~from: int) => t;
 - If `start` is less than or equal to zero, the entire string is returned.
 - If `start` is greater than or equal to the length of `str`, the empty string is returned.
 
+See [`String.substring`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) on MDN.
+
 ```re example
-Js.log(Js.String2.substringToEnd("playground", ~from=4) == "ground");
-Js.log(Js.String2.substringToEnd("playground", ~from=(-3)) == "playground");
-Js.log(Js.String2.substringToEnd("playground", ~from=12) == "");
+Js.String2.substringToEnd("playground", ~from=4) == "ground";
+Js.String2.substringToEnd("playground", ~from=(-3)) == "playground";
+Js.String2.substringToEnd("playground", ~from=12) == "";
 ```
 
 ## toLowerCase
@@ -680,12 +693,12 @@ let toLowerCase: t => t;
 ```
 
 `toLowerCase(str)` converts `str` to lower case using the locale-insensitive case mappings in the Unicode Character Database.
-Notice that the conversion can give different results depending upon context, for example with the Greek letter sigma, which has two different lower case forms when it is the last character in a string or not.
+Notice that the conversion can give different results depending upon context, for example with the Greek letter sigma, which has two different lower case forms; one when it is the last character in a string and another when it is not. See [`String.toLowerCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase) on MDN.
 
 ```re example
-Js.log(Js.String2.toLowerCase("ABC") == "abc");
-Js.log(Js.String2.toLowerCase({js|ΣΠ|js}) == {js|σπ|js});
-Js.log(Js.String2.toLowerCase({js|ΠΣ|js}) == {js|πς|js});
+Js.String2.toLowerCase("ABC") == "abc";
+Js.String2.toLowerCase({js|ΣΠ|js}) == {js|σπ|js};
+Js.String2.toLowerCase({js|ΠΣ|js}) == {js|πς|js};
 ```
 
 ## toLocaleLowerCase
@@ -694,7 +707,7 @@ Js.log(Js.String2.toLowerCase({js|ΠΣ|js}) == {js|πς|js});
 let toLocaleLowerCase: t => t;
 ```
 
-`toLocaleLowerCase(str)` converts `str` to lower case using the current locale.
+`toLocaleLowerCase(str)` converts `str` to lower case using the current locale. See [`String.toLocaleLowerCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase) on MDN.
 
 ## toUpperCase
 
@@ -703,12 +716,12 @@ let toUpperCase: t => t;
 ```
 
 `toUpperCase(str)` converts `str` to upper case using the locale-insensitive case mappings in the Unicode Character Database. 
-Notice that the conversion can expand the number of letters in the result; for example the German ß capitalizes to two Ses in a row.
+Notice that the conversion can expand the number of letters in the result; for example the German ß capitalizes to two Ses in a row. See [`String.toUpperCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toUpperCase) on MDN.
 
 ```re example
-Js.log(Js.String2.toUpperCase("abc") == "ABC");
-Js.log(Js.String2.toUpperCase({js|Straße|js}) == {js|STRASSE|js});
-Js.log(Js.String2.toUpperCase({js|πς|js}) == {js|ΠΣ|js});
+Js.String2.toUpperCase("abc") == "ABC";
+Js.String2.toUpperCase({js|Straße|js}) == {js|STRASSE|js};
+Js.String2.toUpperCase({js|πς|js}) == {js|ΠΣ|js};
 ```
 
 ## toLocaleUpperCase
@@ -717,7 +730,7 @@ Js.log(Js.String2.toUpperCase({js|πς|js}) == {js|ΠΣ|js});
 let toLocaleUpperCase: t => t;
 ```
 
-`toLocaleUpperCase(str)` converts `str` to upper case using the current locale.
+`toLocaleUpperCase(str)` converts `str` to upper case using the current locale. See [`String.to:LocaleUpperCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase) on MDN.
 
 ## trim
 
@@ -725,11 +738,11 @@ let toLocaleUpperCase: t => t;
 let trim: t => t;
 ```
 
-`trim(str)` returns a string that is `str` with whitespace stripped from both ends. Internal whitespace is not removed.
+`trim(str)` returns a string that is `str` with whitespace stripped from both ends. Internal whitespace is not removed. See [`String.trim`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim) on MDN.
 
 ```re example
-Js.log(Js.String2.trim("   abc def   ") == "abc def");
-Js.log(Js.String2.trim("\n\r\t abc def \n\n\t\r ") == "abc def");
+Js.String2.trim("   abc def   ") == "abc def";
+Js.String2.trim("\n\r\t abc def \n\n\t\r ") == "abc def";
 ```
 
 ## anchor
@@ -738,10 +751,10 @@ Js.log(Js.String2.trim("\n\r\t abc def \n\n\t\r ") == "abc def");
 let anchor: (t, t) => t;
 ```
 
-`anchor(anchorText, anchorName)` creates a string with an HTML `<a>` element with name attribute of `anchorName` and `anchorText` as its content.
+`anchor(anchorText, anchorName)` creates a string with an HTML `<a>` element with name attribute of `anchorName` and `anchorText` as its content. Please do not use this method, as it has been removed from the relevant web standards. See [`String.anchor`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/anchor) on MDN.
 
 ```re example
-Js.log(Js.String2.anchor("Page One", "page1")); /* prints "<a name=\"page1\">Page One</a>" */
+Js.String2.anchor("Page One", "page1") == "<a name=\"page1\">Page One</a>";
 ```
 
 ## link
@@ -750,10 +763,10 @@ Js.log(Js.String2.anchor("Page One", "page1")); /* prints "<a name=\"page1\">Pag
 let link: (t, t) => t;
 ```
 
-ES2015: `link(linkText, urlText)` creates a string with an HTML `<a>` element with href attribute of `urlText` and `linkText` as its content.
+ES2015: `link(linkText, urlText)` creates a string with an HTML `<a>` element with href attribute of `urlText` and `linkText` as its content. Please do not use this method, as it has been removed from the relevant web standards. See [`String.link`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/link) on MDN.
 
 ```re example
-Js.log(Js.String2.link("Go to page two", "page2.html")); /* prints "<a href=\"page2.html\">Go to page two</a>" */
+Js.String2.link("Go to page two", "page2.html") == "<a href=\"page2.html\">Go to page two</a>";
 ```
 
 ## castToArrayLike
@@ -762,4 +775,10 @@ Js.log(Js.String2.link("Go to page two", "page2.html")); /* prints "<a href=\"pa
 let castToArrayLike: t => Js_array2.array_like(t);
 ```
 
-ES2015  
+Casts its argument to an `array_like` entity that can be processed by functions such as `Js.Array2.fromMap()`
+
+```re example
+let s = "abcde";
+let arr = Js.Array2.fromMap(Js.String2.castToArrayLike(s), (x)=>{x});
+arr == [|"a", "b", "c", "d", "e"|];
+```

--- a/pages/apis/javascript/latest/js/string.mdx
+++ b/pages/apis/javascript/latest/js/string.mdx
@@ -709,7 +709,7 @@ let toLowerCase: t => t;
 ```
 
 `toLowerCase(str)` converts `str` to lower case using the locale-insensitive case mappings in the Unicode Character Database.
-Notice that the conversion can give different results depending upon context, for example with the Greek letter sigma, which has two different lower case forms; one when it is the last character in a string and one when it is not. See [`String.toLowerCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase) on MDN.
+Notice that the conversion can give different results depending upon context, for example with the Greek letter sigma, which has two different lower case forms; one when it is the last character in a string and another when it is not. See [`String.toLowerCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase) on MDN.
 
 ```re example
 Js.String.toLowerCase("ABC") == "abc";

--- a/pages/apis/javascript/latest/js/string.mdx
+++ b/pages/apis/javascript/latest/js/string.mdx
@@ -406,12 +406,11 @@ The function receives as its parameters the matched string, the offset at which 
 ```re example
 let str = "beautiful vowels";
 let re = [%re "/[aeiou]/g"];
-let matchFn = (matchPart, offset, wholeString) =>
+let matchFn = (matchPart, _offset, _wholeString) =>
   Js.String.toUpperCase(matchPart);
 
-let replaced = Js.String.unsafeReplaceBy0(re, matchFn, str);
-
-Js.log(replaced); /* prints "bEAUtifUl vOwEls" */
+Js.String.unsafeReplaceBy0(re, matchFn, str)
+  == "bEAUtIfUl vOwEls";
 ```
 
 ## unsafeReplaceBy1
@@ -426,12 +425,11 @@ The function receives as its parameters the matched string, the captured string,
 ```re example
 let str = "increment 23";
 let re = [%re "/increment (\\d+)/g"];
-let matchFn = (matchPart, p1, offset, wholeString) =>
+let matchFn = (_matchPart, p1, _offset, wholeString) =>
   wholeString ++ " is " ++ string_of_int(int_of_string(p1) + 1);
 
-let replaced = Js.String.unsafeReplaceBy1(re, matchFn, str);
-
-Js.log(replaced); /* prints "increment 23 is 24" */
+Js.String.unsafeReplaceBy1(re, matchFn, str)
+  == "increment 23 is 24";
 ```
 
 ## unsafeReplaceBy2
@@ -446,12 +444,10 @@ The function receives as its parameters the matched string, the captured strings
 ```re example
 let str = "7 times 6";
 let re = [%re "/(\\d+) times (\\d+)/"];
-let matchFn = (matchPart, p1, p2, offset, wholeString) =>
+let matchFn = (_matchPart, p1, p2, _offset, _wholeString) =>
   string_of_int(int_of_string(p1) * int_of_string(p2));
 
-let replaced = Js.String.unsafeReplaceBy2(re, matchFn, str);
-
-Js.log(replaced); /* prints "42" */
+Js.String.unsafeReplaceBy2(re, matchFn, str) == "42";
 ```
 
 ## unsafeReplaceBy3
@@ -561,10 +557,8 @@ let splitByRe: (Js_re.t, t) => array(option(t));
 `splitByRe(regex, str)` splits the given `str` at every occurrence of `regex` and returns an array of the resulting substrings. See [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.
 
 ```re example
-Js.log(
-  Js.String.splitByRe([%re "/\\s*[,;]\\s*/"], "art; bed , cog ;dad")
-  == [|Some("art"), Some("bed"), Some("cog"), Some("dad")|],
-);
+Js.String.splitByRe([%re "/\\s*[,;]\\s*/"], "art; bed , cog ;dad")
+  == [|Some("art"), Some("bed"), Some("cog"), Some("dad")|];
 ```
 
 ## splitByReAtMost
@@ -577,18 +571,14 @@ let splitByReAtMost: (Js_re.t, ~limit: int, t) => array(option(t));
 If `n` is negative or greater than the number of substrings, the array will contain all the substrings. See [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.
 
 ```re example
-Js.log(
-  Js.String.splitByReAtMost([%re "/\\s*:\\s*/"], ~limit=3, "one: two: three: four")
-  == [|Some("one"), Some("two"), Some("three")|],
-);
-Js.log(
-  Js.String.splitByReAtMost([%re "/\\s*:\\s*/"], ~limit=0, "one: two: three: four")
-  == [||],
-);
-Js.log(
-  Js.String.splitByReAtMost([%re "/\\s*:\\s*/"], ~limit=8, "one: two: three: four")
-  == [|Some("one"), Some("two"), Some("three"), Some("four")|],
-);
+Js.String.splitByReAtMost([%re "/\\s*:\\s*/"], ~limit=3, "one: two: three: four")
+  == [|Some("one"), Some("two"), Some("three")|];
+
+Js.String.splitByReAtMost([%re "/\\s*:\\s*/"], ~limit=0, "one: two: three: four")
+  == [||];
+
+Js.String.splitByReAtMost([%re "/\\s*:\\s*/"], ~limit=8, "one: two: three: four")
+  == [|Some("one"), Some("two"), Some("three"), Some("four")|];
 ```
 
 ## splitRegexpLimited

--- a/pages/apis/javascript/latest/js/string.mdx
+++ b/pages/apis/javascript/latest/js/string.mdx
@@ -21,8 +21,8 @@ let make: 'a => t;
 `make(value)` converts the given value to a `string`.
 
 ```re example
-Js.log(Js.String2.make(3.5) == "3.5");
-Js.log(Js.String2.make([|1,2,3|]) == "1,2,3");
+Js.String2.make(3.5) == "3.5";
+Js.String2.make([|1,2,3|]) == "1,2,3";
 ```
 
 ## fromCharCode
@@ -32,13 +32,13 @@ let fromCharCode: int => t;
 ```
 
 `fromCharCode(n)` creates a `string` containing the character corresponding to that number; `n` ranges from 0 to 65535.
-If out of range, the lower 16 bits of the value are used. Thus, `fromCharCode(0x1F63A)` gives the same result as `fromCharCode(0xF63A)`.
+If out of range, the lower 16 bits of the value are used. Thus, `fromCharCode(0x1F63A)` gives the same result as `fromCharCode(0xF63A)`. See [`String.fromCharCode`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode) on MDN.
 
 ```re sig
-Js.log(Js.String2.fromCharCode(65) == "A");
-Js.log(Js.String2.fromCharCode(0x3c8) == {js|ψ|js});
-Js.log(Js.String2.fromCharCode(0xd55c) == {js|한|js});
-Js.log(Js.String2.fromCharCode(-64568) == {js|ψ|js});
+Js.String2.fromCharCode(65) == "A";
+Js.String2.fromCharCode(0x3c8) == {js|ψ|js};
+Js.String2.fromCharCode(0xd55c) == {js|한|js};
+Js.String2.fromCharCode(-64568) == {js|ψ|js};
 ```
 
 ## fromCharCodeMany
@@ -47,7 +47,7 @@ Js.log(Js.String2.fromCharCode(-64568) == {js|ψ|js});
 let fromCharCodeMany: array(int) => t;
 ```
 
-`fromCharCodeMany([|n1;n2;n3|])` creates a `string` from the characters corresponding to the given numbers, using the same rules as `fromCharCode`.
+`fromCharCodeMany([|n1;n2;n3|])` creates a `string` from the characters corresponding to the given numbers, using the same rules as `fromCharCode`. See [`String.fromCharCode`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode) on MDN.
 
 ## fromCodePoint
 
@@ -57,13 +57,13 @@ let fromCodePoint: int => t;
 
 `fromCodePoint(n)` creates a `string` containing the character corresponding to that numeric code point. 
 If the number is not a valid code point, it raises `RangeError`. 
-Thus, `fromCodePoint(0x1F63A)` will produce a correct value, unlike `fromCharCode(0x1F63A)`, and `fromCodePoint(-5)` will raise a `RangeError`.
+Thus, `fromCodePoint(0x1F63A)` will produce a correct value, unlike `fromCharCode(0x1F63A)`, and `fromCodePoint(-5)` will raise a `RangeError`. See [`String.fromCodePoint`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint) on MDN.
  
 ```re example
-Js.log(Js.String2.fromCodePoint(65) == "A");
-Js.log(Js.String2.fromCodePoint(0x3c8) == {js|ψ|js});
-Js.log(Js.String2.fromCodePoint(0xd55c) == {js|한|js});
-Js.log(Js.String2.fromCodePoint(0x1f63a) == {js|😺|js});
+Js.String2.fromCodePoint(65) == "A";
+Js.String2.fromCodePoint(0x3c8) == {js|ψ|js};
+Js.String2.fromCodePoint(0xd55c) == {js|한|js};
+Js.String2.fromCodePoint(0x1f63a) == {js|😺|js};
 ```
 
 ## fromCodePointMany
@@ -72,10 +72,10 @@ Js.log(Js.String2.fromCodePoint(0x1f63a) == {js|😺|js});
 let fromCodePointMany: array(int) => t;
 ```
 
-`fromCodePointMany([|n1;n2;n3|])` creates a `string` from the characters corresponding to the given code point numbers, using the same rules as `fromCodePoint`.
+`fromCodePointMany([|n1;n2;n3|])` creates a `string` from the characters corresponding to the given code point numbers, using the same rules as `fromCodePoint`. See [`String.fromCodePoint`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint) on MDN.
 
 ```re example
-Js.log(Js.String2.fromCodePointMany([|0xd55c, 0xae00, 0x1f63a|]) == {js|한글😺|js});
+Js.String2.fromCodePointMany([|0xd55c, 0xae00, 0x1f63a|]) == {js|한글😺|js};
 ```
 
 ## length
@@ -84,10 +84,10 @@ Js.log(Js.String2.fromCodePointMany([|0xd55c, 0xae00, 0x1f63a|]) == {js|한글�
 let length: t => int;
 ```
 
-`length(s)` returns the length of the given `string`.
+`length(s)` returns the length of the given `string`. See [`String.length`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length) on MDN.
 
 ```re example
-Js.log(Js.String2.length("abcd") == 4);
+Js.String2.length("abcd") == 4;
 ```
 
 ## get
@@ -97,12 +97,12 @@ let get: (t, int) => t;
 ```
 
 `get(s, n)` returns as a `string` the character at the given index number. 
-If `n` is out of range, this function returns `undefined`,so at some point this function may be modified to return `option(string)`.
+If `n` is out of range, this function returns `undefined`, so at some point this function may be modified to return `option(string)`.
 
 ```re example
-Js.log(Js.String2.get("Reason", 0) == "R");
-Js.log(Js.String2.get("Reason", 4) == "o");
-Js.log(Js.String2.get({js|Rẽasöń|js}, 5) == {js|ń|js});
+Js.String2.get("Reason", 0) == "R";
+Js.String2.get("Reason", 4) == "o";
+Js.String2.get({js|Rẽasöń|js}, 5) == {js|ń|js};
 ```
 
 ## charAt
@@ -113,12 +113,12 @@ let charAt: (int, t) => t;
 
 `charAt(n, s)` gets the character at index `n` within string `s`. 
 If `n` is negative or greater than the length of `s`, it returns the empty string.
-If the string contains characters outside the range \u0000-\uffff, it will return the first 16-bit value at that position in the string.
+If the string contains characters outside the range \u0000-\uffff, it will return the first 16-bit value at that position in the string. See [`String.charAt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charAt) on MDN.
 
 ```re example
-Js.log(Js.String.charAt(0, "Reason") == "R");
-Js.log(Js.String.charAt(12, "Reason") == "");
-Js.log(Js.String.charAt(5, {js|Rẽasöń|js}) == {js|ń|js});
+Js.String.charAt(0, "Reason") == "R";
+Js.String.charAt(12, "Reason") == "";
+Js.String.charAt(5, {js|Rẽasöń|js}) == {js|ń|js};
 ```
 
 ## charCodeAt
@@ -128,11 +128,11 @@ let charCodeAt: (int, t) => float;
 ```
 
 `charCodeAt(n, s)` returns the character code at position `n` in string `s`; the result is in the range 0-65535, unlke `codePointAt`, so it will not work correctly for characters with code points greater than or equal to 0x10000. 
-The return type is `float` because this function returns NaN if `n` is less than zero or greater than the length of the string.
+The return type is `float` because this function returns NaN if `n` is less than zero or greater than the length of the string. See [`String.charCodeAt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt) on MDN.
 
 ```re example
-Js.log(Js.String.charCodeAt(0, {js|😺|js}) == 0xd83d->float_of_int);
-Js.log(Js.String.codePointAt(0, {js|😺|js}) == Some(0x1f63a));
+Js.String.charCodeAt(0, {js|😺|js}) == 0xd83d->float_of_int;
+Js.String.codePointAt(0, {js|😺|js}) == Some(0x1f63a);
 ```
 
 ## codePointAt
@@ -143,11 +143,11 @@ let codePointAt: (int, t) => option(int);
 
 `codePointAt(n, s)` returns the code point at position `n` within string `s` as a `Some(value)`. 
 The return value handles code points greater than or equal to 0x10000.
-If there is no code point at the given position, the function returns `None`.
+If there is no code point at the given position, the function returns `None`. See [`String.codePointAt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/codePointAt) on MDN.
 
 ```re example
-Js.log(Js.String.codePointAt(1, {js|¿😺?|js}) == Some(0x1f63a));
-Js.log(Js.String.codePointAt(5, "abc") == None);
+Js.String.codePointAt(1, {js|¿😺?|js}) == Some(0x1f63a);
+Js.String.codePointAt(5, "abc") == None;
 ```
 
 ## concat
@@ -156,10 +156,10 @@ Js.log(Js.String.codePointAt(5, "abc") == None);
 let concat: (t, t) => t;
 ```
 
-`concat(append, original)` returns a new `string` with `append` added after `original`.
+`concat(append, original)` returns a new `string` with `append` added after `original`. See [`String.concat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/concat) on MDN.
 
 ```re example
-Js.log(Js.String.concat("bell", "cow") == "cowbell");
+Js.String.concat("bell", "cow") == "cowbell";
 ```
 
 ## concatMany
@@ -168,10 +168,10 @@ Js.log(Js.String.concat("bell", "cow") == "cowbell");
 let concatMany: (array(t), t) => t;
 ```
 
-`concat(arr, original)` returns a new `string` consisting of each item of an array of strings added to the `original` string.
+`concat(arr, original)` returns a new `string` consisting of each item of an array of strings added to the `original` string. See [`String.concat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/concat) on MDN.
 
 ```re example
-Js.log(Js.String.concatMany([|"2nd", "3rd", "4th"|], "1st") == "1st2nd3rd4th");
+Js.String.concatMany([|"2nd", "3rd", "4th"|], "1st") == "1st2nd3rd4th";
 ```
 
 ## endsWith
@@ -180,11 +180,11 @@ Js.log(Js.String.concatMany([|"2nd", "3rd", "4th"|], "1st") == "1st2nd3rd4th");
 let endsWith: (t, t) => bool;
 ```
 
-ES2015: `endsWith(substr, str)` returns `true` if the `str` ends with `substr`, `false` otherwise.
+ES2015: `endsWith(substr, str)` returns `true` if the `str` ends with `substr`, `false` otherwise. See [`String.endsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith) on MDN.
 
 ```re example
-Js.log(Js.String.endsWith("Script", "BuckleScript") == true);
-Js.log(Js.String.endsWith("Script", "BuckleShoes") == false);
+Js.String.endsWith("Script", "BuckleScript") == true;
+Js.String.endsWith("Script", "BuckleShoes") == false;
 ```
 
 ## endsWithFrom
@@ -194,13 +194,13 @@ let endsWithFrom: (t, int, t) => bool;
 ```
 
 `endsWithFrom(ending, len, str)` returns `true` if the first len characters of `str` end with `ending`, `false` otherwise.
-If `len` is greater than or equal to the length of `str`, then it works like `endsWith`. (Honestly, this should have been named endsWithAt, but oh well.)
+If `len` is greater than or equal to the length of `str`, then it works like `endsWith`. (Honestly, this should have been named endsWithAt, but oh well.) See [`String.endsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith) on MDN.
 
 ```re example
-Js.log(Js.String.endsWithFrom("cd", 4, "abcd") == true);
-Js.log(Js.String.endsWithFrom("cd", 3, "abcde") == false);
-Js.log(Js.String.endsWithFrom("cde", 99, "abcde",) == true);
-Js.log(Js.String.endsWithFrom("ple", 7, "example.dat") == true);
+Js.String.endsWithFrom("cd", 4, "abcd") == true;
+Js.String.endsWithFrom("cd", 3, "abcde") == false;
+Js.String.endsWithFrom("cde", 99, "abcde",) == true;
+Js.String.endsWithFrom("ple", 7, "example.dat") == true;
 ```
 
 ## includes
@@ -209,13 +209,13 @@ Js.log(Js.String.endsWithFrom("ple", 7, "example.dat") == true);
 let includes: (t, t) => bool;
 ```
 
-ES2015: `includes(searchValue, str)` returns `true` if `searchValue` is found anywhere within `str`, false otherwise.
+ES2015: `includes(searchValue, str)` returns `true` if `searchValue` is found anywhere within `str`, false otherwise. See [`String.includes`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes) on MDN.
 
 ```re example
-Js.log(Js.String.includes("gram", "programmer") == true);
-Js.log(Js.String.includes("er", "programmer") == true);
-Js.log(Js.String.includes("pro", "programmer") == true);
-Js.log(Js.String.includes("xyz", "programmer.dat") == false);
+Js.String.includes("gram", "programmer") == true;
+Js.String.includes("er", "programmer") == true;
+Js.String.includes("pro", "programmer") == true;
+Js.String.includes("xyz", "programmer.dat") == false;
 ```
 
 ## includesFrom
@@ -224,12 +224,12 @@ Js.log(Js.String.includes("xyz", "programmer.dat") == false);
 let includesFrom: (t, int, t) => bool;
 ```
 
-ES2015: `includes(searchValue start, str)` returns `true` if `searchValue` is found anywhere within `str` starting at character number `start` (where 0 is the first character), `false` otherwise.
+ES2015: `includes(searchValue start, str)` returns `true` if `searchValue` is found anywhere within `str` starting at character number `start` (where 0 is the first character), `false` otherwise. See [`String.includes`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes) on MDN.
 
 ```re example
-Js.log(Js.String.includesFrom("gram", 1, "programmer") == true);
-Js.log(Js.String.includesFrom("gram", 4, "programmer") == false);
-Js.log(Js.String.includesFrom({js|한|js}, 1, {js|대한민국|js}) == true);
+Js.String.includesFrom("gram", 1, "programmer") == true;
+Js.String.includesFrom("gram", 4, "programmer") == false;
+Js.String.includesFrom({js|한|js}, 1, {js|대한민국|js}) == true;
 ```
 
 ## indexOf
@@ -238,13 +238,13 @@ Js.log(Js.String.includesFrom({js|한|js}, 1, {js|대한민국|js}) == true);
 let indexOf: (t, t) => int;
 ```
 
-ES2015: `indexOf(searchValue, str)` returns the position at which `searchValue` was first found within `str`, or -1 if `searchValue` is not in `str`.
+ES2015: `indexOf(searchValue, str)` returns the position at which `searchValue` was first found within `str`, or -1 if `searchValue` is not in `str`. See [`String.indexOf`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf) on MDN.
 
 ```re example
-Js.log(Js.String.indexOf("ok", "bookseller") == 2);
-Js.log(Js.String.indexOf("sell", "bookseller") == 4);
-Js.log(Js.String.indexOf( "ee", "beekeeper") == 1);
-Js.log(Js.String.indexOf("xyz", "bookseller") == -1);
+Js.String.indexOf("ok", "bookseller") == 2;
+Js.String.indexOf("sell", "bookseller") == 4;
+Js.String.indexOf( "ee", "beekeeper") == 1;
+Js.String.indexOf("xyz", "bookseller") == -1;
 ```
 
 ## indexOfFrom
@@ -253,12 +253,12 @@ Js.log(Js.String.indexOf("xyz", "bookseller") == -1);
 let indexOfFrom: (t, t, int) => int;
 ```
 `indexOfFrom(searchValue, start, str)` returns the position at which `searchValue` was found within `str` starting at character position `start`, or -1 if `searchValue` is not found in that portion of `str`.
-The return value is relative to the beginning of the string, no matter where the search started from.
+The return value is relative to the beginning of the string, no matter where the search started from. See [`String.indexOf`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf) on MDN.
 
 ```re example
-Js.log(Js.String.indexOfFrom("ok", 1, "bookseller") == 2);
-Js.log(Js.String.indexOfFrom("sell", 2, "bookseller") == 4);
-Js.log(Js.String.indexOfFrom("sell", 5, "bookseller") == -1);
+Js.String.indexOfFrom("ok", 1, "bookseller") == 2;
+Js.String.indexOfFrom("sell", 2, "bookseller") == 4;
+Js.String.indexOfFrom("sell", 5, "bookseller") == -1;
 ```
 
 ## lastIndexOf
@@ -268,12 +268,12 @@ let lastIndexOf: (t, t) => int;
 ```
 
 `lastIndexOf(searchValue, str)` returns the position of the last occurrence of `searchValue` within `str`, searching backwards from the end of the string.
-Returns -1 if `searchValue` is not in `str`. The return value is always relative to the beginning of the string.
+Returns -1 if `searchValue` is not in `str`. The return value is always relative to the beginning of the string. See [`String.lastIndexOf`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/lastIndexOf) on MDN.
 
 ```re example
-Js.log(Js.String.lastIndexOf("ok", "bookseller") == 2);
-Js.log(Js.String.lastIndexOf("ee", "beekeeper") == 4);
-Js.log(Js.String.lastIndexOf("xyz", "abcdefg") == -1);
+Js.String.lastIndexOf("ok", "bookseller") == 2;
+Js.String.lastIndexOf("ee", "beekeeper") == 4;
+Js.String.lastIndexOf("xyz", "abcdefg") == -1;
 ```
 
 ## lastIndexOfFrom
@@ -283,13 +283,13 @@ let lastIndexOfFrom: (t, int, t) => int;
 ```
 
 `lastIndexOfFrom(searchValue, start, str)` returns the position of the last occurrence of `searchValue` within `str`, searching backwards from the given start position.
-Returns -1 if `searchValue` is not in `str`. The return value is always relative to the beginning of the string.
+Returns -1 if `searchValue` is not in `str`. The return value is always relative to the beginning of the string. See [`String.lastIndexOf`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/lastIndexOf) on MDN.
 
 ```re example
-Js.log(Js.String.lastIndexOfFrom("ok", 6, "bookseller") == 2);
-Js.log(Js.String.lastIndexOfFrom("ee", 8, "beekeeper") == 4);
-Js.log(Js.String.lastIndexOfFrom("ee", 3, "beekeeper") == 1);
-Js.log(Js.String.lastIndexOfFrom("xyz", 4, "abcdefg") == -1);
+Js.String.lastIndexOfFrom("ok", 6, "bookseller") == 2;
+Js.String.lastIndexOfFrom("ee", 8, "beekeeper") == 4;
+Js.String.lastIndexOfFrom("ee", 3, "beekeeper") == 1;
+Js.String.lastIndexOfFrom("xyz", 4, "abcdefg") == -1;
 ```
 
 ## localeCompare
@@ -303,11 +303,13 @@ let localeCompare: (t, t) => float;
 - zero if reference and comparison have the same sort order
 - a positive value if reference comes after comparison in sort order
 
+See [`String.localeCompare`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare) on MDN.
+
 ```re example
-Js.log(Js.String.localeCompare("ant", "zebra") > 0.0);
-Js.log(Js.String.localeCompare("zebra", "ant") < 0.0);
-Js.log(Js.String.localeCompare("cat", "cat") == 0.0);
-Js.log(Js.String.localeCompare("cat", "CAT") > 0.0);
+Js.String.localeCompare("ant", "zebra") > 0.0;
+Js.String.localeCompare("zebra", "ant") < 0.0;
+Js.String.localeCompare("cat", "cat") == 0.0;
+Js.String.localeCompare("cat", "CAT") > 0.0;
 ```
 
 ## match
@@ -319,13 +321,13 @@ let match: (Js_re.t, t) => option(array(t));
 `match(regexp, str)` matches a `string` against the given `regexp`. If there is no match, it returns `None`. For regular expressions without the g modifier, if there is a match, the return value is `Some(array)` where the array contains:
 - The entire matched string
 - Any capture groups if the regexp had parentheses
-For regular expressions with the g modifier, a matched expression returns `Some(array)` with all the matched substrings and no capture groups.
+For regular expressions with the g modifier, a matched expression returns `Some(array)` with all the matched substrings and no capture groups. See [`String.match`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) on MDN.
 
 ```re example
-Js.log(Js.String.match([%re "/b[aeiou]t/"], "The better bats") == Some([|"bet"|]));
-Js.log(Js.String.match([%re "/b[aeiou]t/g"], "The better bats") == Some([|"bet", "bat"|]));
-Js.log(Js.String.match([%re "/(\\d+)-(\\d+)-(\\d+)/"], "Today is 2018-04-05.") == Some([|"2018-04-05", "2018", "04", "05"|]));
-Js.log(Js.String.match([%re "/b[aeiou]g/"], "The large container.") == None);
+Js.String.match([%re "/b[aeiou]t/"], "The better bats") == Some([|"bet"|]);
+Js.String.match([%re "/b[aeiou]t/g"], "The better bats") == Some([|"bet", "bat"|]);
+Js.String.match([%re "/(\\d+)-(\\d+)-(\\d+)/"], "Today is 2018-04-05.") == Some([|"2018-04-05", "2018", "04", "05"|]);
+Js.String.match([%re "/b[aeiou]g/"], "The large container.") == None;
 ```
 
 ## normalize
@@ -336,8 +338,7 @@ let normalize: t => t;
 
 `normalize(str)` returns the normalized Unicode string using Normalization Form Canonical (NFC) Composition.
 Consider the character ã, which can be represented as the single codepoint \u00e3 or the combination of a lower case letter A \u0061 and a combining tilde \u0303.
-Normalization ensures that both can be stored in an equivalent binary representation.
-See also Unicode technical report for details.
+Normalization ensures that both can be stored in an equivalent binary representation. See [`String.normalize`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize) on MDN. See also [Unicode technical report #15](https://unicode.org/reports/tr15/) for details. 
 
 ## normalizeByForm
 
@@ -351,7 +352,7 @@ ES2015: `normalize(form, str)` returns the normalized Unicode string using the s
 - "NFKC" — Normalization Form Compatibility Composition.
 - "NFKD" — Normalization Form Compatibility Decomposition.
 
-See also Unicode technical report for details.
+See [`String.normalize`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize) on MDN. See also [Unicode technical report #15](https://unicode.org/reports/tr15/) for details.
 
 ## repeat
 
@@ -359,11 +360,11 @@ See also Unicode technical report for details.
 let repeat: (t, int) => t;
 ```
 
-`repeat(n, str)` returns a `string` that consists of `n` repetitions of `str`. Raises `RangeError` if `n` is negative.
+`repeat(n, str)` returns a `string` that consists of `n` repetitions of `str`. Raises `RangeError` if `n` is negative. See [`String.repeat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat) on MDN.
 
 ```re example
-Js.log(Js.String.repeat(3, "ha") == "hahaha");
-Js.log(Js.String.repeat(0, "empty") == "");
+Js.String.repeat(3, "ha") == "hahaha";
+Js.String.repeat(0, "empty") == "";
 ```
 
 ## replace
@@ -373,11 +374,11 @@ let replace: (t, t, t) => t;
 ```
 
 ES2015: `replace(substr, newSubstr, str)` returns a new `string` which is identical to `str` except with the first matching instance of `substr` replaced by `newSubstr`.
-`substr` is treated as a verbatim string to match, not a regular expression.
+`substr` is treated as a verbatim string to match, not a regular expression. See [`String.replace`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) on MDN.
 
 ```re example
-Js.log(Js.String.replace("old", "new", "old string") == "new string");
-Js.log(Js.String.replace("the", "this", "the cat and the dog") == "this cat and the dog");
+Js.String.replace("old", "new", "old string") == "new string";
+Js.String.replace("the", "this", "the cat and the dog") == "this cat and the dog";
 ```
 
 ## replaceByRe
@@ -386,11 +387,11 @@ Js.log(Js.String.replace("the", "this", "the cat and the dog") == "this cat and 
 let replaceByRe: (Js_re.t, t, t) => t;
 ```
 
-`replaceByRe(regex, replacement, str)` returns a new `string` where occurrences matching regex have been replaced by `replacement`.
+`replaceByRe(regex, replacement, str)` returns a new `string` where occurrences matching regex have been replaced by `replacement`. See [`String.replace`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) on MDN.
 
 ```re example
-Js.log(Js.String.replaceByRe([%re "/[aeiou]/g"], "x", "vowels be gone") == "vxwxls bx gxnx");
-Js.log(Js.String.replaceByRe([%re "/(\\w+) (\\w+)/"], "$2, $1", "Juan Fulano") == "Fulano, Juan");
+Js.String.replaceByRe([%re "/[aeiou]/g"], "x", "vowels be gone") == "vxwxls bx gxnx";
+Js.String.replaceByRe([%re "/(\\w+) (\\w+)/"], "$2, $1", "Juan Fulano") == "Fulano, Juan";
 ```
 
 ## unsafeReplaceBy0
@@ -400,7 +401,7 @@ let unsafeReplaceBy0: (Js_re.t, (t, int, t) => t, t) => t;
 ```
 
 Returns a new `string` with some or all matches of a pattern with no capturing parentheses replaced by the value returned from the given function.
-The function receives as its parameters the matched string, the offset at which the match begins, and the whole string being matched.
+The function receives as its parameters the matched string, the offset at which the match begins, and the whole string being matched. See [`String.replace`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) on MDN.
 
 ```re example
 let str = "beautiful vowels";
@@ -420,7 +421,7 @@ let unsafeReplaceBy1: (Js_re.t, (t, t, int, t) => t, t) => t;
 ```
 
 Returns a new `string` with some or all matches of a pattern with one set of capturing parentheses replaced by the value returned from the given function.
-The function receives as its parameters the matched string, the captured string, the offset at which the match begins, and the whole string being matched.
+The function receives as its parameters the matched string, the captured string, the offset at which the match begins, and the whole string being matched. See [`String.replace`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) on MDN.
 
 ```re example
 let str = "increment 23";
@@ -440,7 +441,7 @@ let unsafeReplaceBy2: (Js_re.t, (t, t, t, int, t) => t, t) => t;
 ```
 
 Returns a new `string` with some or all matches of a pattern with two sets of capturing parentheses replaced by the value returned from the given function.
-The function receives as its parameters the matched string, the captured strings, the offset at which the match begins, and the whole string being matched.
+The function receives as its parameters the matched string, the captured strings, the offset at which the match begins, and the whole string being matched. See [`String.replace`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) on MDN.
 
 ```re example
 let str = "7 times 6";
@@ -460,7 +461,7 @@ let unsafeReplaceBy3: (Js_re.t, (t, t, t, t, int, t) => t, t) => t;
 ```
 
 Returns a new `string` with some or all matches of a pattern with three sets of capturing parentheses replaced by the value returned from the given function.
-The function receives as its parameters the matched string, the captured strings, the offset at which the match begins, and the whole string being matched.
+The function receives as its parameters the matched string, the captured strings, the offset at which the match begins, and the whole string being matched. See [`String.replace`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) on MDN.
 
 ## search
 
@@ -468,11 +469,11 @@ The function receives as its parameters the matched string, the captured strings
 let search: (Js_re.t, t) => int;
 ```
 
-`search(regexp, str)` returns the starting position of the first match of `regexp` in the given `str`, or -1 if there is no match.
+`search(regexp, str)` returns the starting position of the first match of `regexp` in the given `str`, or -1 if there is no match. See [`String.search`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/search) on MDN.
 
 ```re example
-Js.log(Js.String.search([%re "/\\d+/"], "testing 1 2 3") == 8);
-Js.log(Js.String.search([%re "/\\d+/"], "no numbers") == -1);
+Js.String.search([%re "/\\d+/"], "testing 1 2 3") == 8;
+Js.String.search([%re "/\\d+/"], "no numbers") == -1;
 ```
 
 ## slice
@@ -486,11 +487,13 @@ let slice: (~from: int, ~to_: int, t) => t;
 - If `n2` is greater than the length of `str`, then it is treated as `length(str)`.
 - If `n1` is greater than `n2`, slice returns the empty string.
 
+See [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.
+
 ```re example
-Js.log(Js.String.slice(~from=2, ~to_=5, "abcdefg") == "cde");
-Js.log(Js.String.slice(~from=2, ~to_=9, "abcdefg") == "cdefg");
-Js.log(Js.String.slice(~from=(-4), ~to_=(-2), "abcdefg") == "de");
-Js.log(Js.String.slice(~from=5, ~to_=1, "abcdefg") == "");
+Js.String.slice(~from=2, ~to_=5, "abcdefg") == "cde";
+Js.String.slice(~from=2, ~to_=9, "abcdefg") == "cdefg";
+Js.String.slice(~from=(-4), ~to_=(-2), "abcdefg") == "de";
+Js.String.slice(~from=5, ~to_=1, "abcdefg") == "";
 ```
 
 ## sliceToEnd
@@ -503,10 +506,12 @@ let sliceToEnd: (~from: int, t) => t;
 - If `n` is negative, then it is evaluated as `length(str - n)`.
 - If `n` is greater than the length of `str`, then sliceToEnd returns the empty string.
 
+See [`String.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) on MDN.
+
 ```re example
-Js.log(Js.String.sliceToEnd(~from=4, "abcdefg") == "efg");
-Js.log(Js.String.sliceToEnd(~from=(-2), "abcdefg") == "fg");
-Js.log(Js.String.sliceToEnd(~from=7, "abcdefg") == "");
+Js.String.sliceToEnd(~from=4, "abcdefg") == "efg";
+Js.String.sliceToEnd(~from=(-2), "abcdefg") == "fg";
+Js.String.sliceToEnd(~from=7, "abcdefg") == "";
 ```
 
 ## split
@@ -515,13 +520,13 @@ Js.log(Js.String.sliceToEnd(~from=7, "abcdefg") == "");
 let split: (t, t) => array(t);
 ```
 
-`split(delimiter, str)` splits the given `str` at every occurrence of `delimiter` and returns an array of the resulting substrings.
+`split(delimiter, str)` splits the given `str` at every occurrence of `delimiter` and returns an array of the resulting substrings. See [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.
 
 ```re example
-Js.log(Js.String.split("-", "2018-01-02") == [|"2018", "01", "02"|]);
-Js.log(Js.String.split(",", "a,b,,c") == [|"a", "b", "", "c"|]);
-Js.log(Js.String.split("::", "good::bad as great::awful") == [|"good", "bad as great", "awful"|]);
-Js.log(Js.String.split(";", "has-no-delimiter") == [|"has-no-delimiter"|]);
+Js.String.split("-", "2018-01-02") == [|"2018", "01", "02"|];
+Js.String.split(",", "a,b,,c") == [|"a", "b", "", "c"|];
+Js.String.split("::", "good::bad as great::awful") == [|"good", "bad as great", "awful"|];
+Js.String.split(";", "has-no-delimiter") == [|"has-no-delimiter"|];
 ```
 
 ## splitAtMost
@@ -531,12 +536,12 @@ let splitAtMost: (t, ~limit: int, t) => array(t);
 ```
 
 `splitAtMost(delimiter, ~limit:n, str)` splits the given `str` at every occurrence of `delimiter` and returns an array of the first `n` resulting substrings.
-If `n` is negative or greater than the number of substrings, the array will contain all the substrings.
+If `n` is negative or greater than the number of substrings, the array will contain all the substrings. See [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.
 
 ```re example
-Js.log(Js.String.splitAtMost("/", ~limit=3, "ant/bee/cat/dog/elk") == [|"ant", "bee", "cat"|]);
-Js.log(Js.String.splitAtMost("/", ~limit=0, "ant/bee/cat/dog/elk") == [||]);
-Js.log(Js.String.splitAtMost("/", ~limit=9, "ant/bee/cat/dog/elk") == [|"ant", "bee", "cat", "dog", "elk"|]);
+Js.String.splitAtMost("/", ~limit=3, "ant/bee/cat/dog/elk") == [|"ant", "bee", "cat"|];
+Js.String.splitAtMost("/", ~limit=0, "ant/bee/cat/dog/elk") == [||];
+Js.String.splitAtMost("/", ~limit=9, "ant/bee/cat/dog/elk") == [|"ant", "bee", "cat", "dog", "elk"|];
 ```
 
 ## splitLimited
@@ -553,7 +558,7 @@ Deprecated - Please use splitAtMost.
 let splitByRe: (Js_re.t, t) => array(option(t));
 ```
 
-`splitByRe(regex, str)` splits the given `str` at every occurrence of `regex` and returns an array of the resulting substrings.
+`splitByRe(regex, str)` splits the given `str` at every occurrence of `regex` and returns an array of the resulting substrings. See [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.
 
 ```re example
 Js.log(
@@ -569,7 +574,7 @@ let splitByReAtMost: (Js_re.t, ~limit: int, t) => array(option(t));
 ```
 
 `splitByReAtMost(regex, ~limit:n, str)` splits the given `str` at every occurrence of `regex` and returns an array of the first `n` resulting substrings.
-If `n` is negative or greater than the number of substrings, the array will contain all the substrings.
+If `n` is negative or greater than the number of substrings, the array will contain all the substrings. See [`String.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) on MDN.
 
 ```re example
 Js.log(
@@ -600,12 +605,12 @@ Deprecated - Please use splitByReAtMost.
 let startsWith: (t, t) => bool;
 ```
 
-ES2015: `startsWith(substr, str)` returns `true` if the `str` starts with `substr`, `false` otherwise.
+ES2015: `startsWith(substr, str)` returns `true` if the `str` starts with `substr`, `false` otherwise. See [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.
 
 ```re example
-Js.log(Js.String.startsWith("Buckle", "BuckleScript") == true);
-Js.log(Js.String.startsWith("", "BuckleScript") == true);
-Js.log(Js.String.startsWith("Buckle", "JavaScript") == false);
+Js.String.startsWith("Buckle", "BuckleScript") == true;
+Js.String.startsWith("", "BuckleScript") == true;
+Js.String.startsWith("Buckle", "JavaScript") == false;
 ```
 
 ## startsWithFrom
@@ -615,12 +620,12 @@ let startsWithFrom: (t, int, t) => bool;
 ```
 
 ES2015: `startsWithFrom(substr, n, str)` returns `true` if the `str` starts with `substr` starting at position `n`, false otherwise.
-If `n` is negative, the search starts at the beginning of `str`.
+If `n` is negative, the search starts at the beginning of `str`. See [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) on MDN.
 
 ```re example
-Js.log(Js.String.startsWithFrom("kle", 3, "BuckleScript") == true);
-Js.log(Js.String.startsWithFrom("", 3, "BuckleScript") == true);
-Js.log(Js.String.startsWithFrom("Buckle", 2, "JavaScript") == false);
+Js.String.startsWithFrom("kle", 3, "BuckleScript") == true;
+Js.String.startsWithFrom("", 3, "BuckleScript") == true;
+Js.String.startsWithFrom("Buckle", 2, "JavaScript") == false;
 ```
 
 ## substr
@@ -633,10 +638,12 @@ let substr: (~from: int, t) => t;
 - If `n` is less than zero, the starting position is the length of `str - n`.
 - If `n` is greater than or equal to the length of `str`, returns the empty string.
 
+JavaScript’s `String.substr()` is a legacy function. When possible, use `substring()` instead. See [`String.substr`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) on MDN.
+
 ```re example
-Js.log(Js.String.substr(~from=3, "abcdefghij") == "defghij");
-Js.log(Js.String.substr(~from=(-3), "abcdefghij") == "hij");
-Js.log(Js.String.substr(~from=12, "abcdefghij") == "");
+Js.String.substr(~from=3, "abcdefghij") == "defghij";
+Js.String.substr(~from=(-3), "abcdefghij") == "hij";
+Js.String.substr(~from=12, "abcdefghij") == "";
 ```
 
 ## substrAtMost
@@ -650,10 +657,12 @@ let substrAtMost: (~from: int, ~length: int, t) => t;
 - If `pos` is greater than or equal to the length of `str`, returns the empty string.
 - If `n` is less than or equal to zero, returns the empty string.
 
+JavaScript’s `String.substr()` is a legacy function. When possible, use `substring()` instead. See [`String.substr`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) on MDN.
+
 ```re example
-Js.log(Js.String.substrAtMost(~from=3, ~length=4, "abcdefghij") == "defg");
-Js.log(Js.String.substrAtMost(~from=(-3), ~length=4, "abcdefghij") == "hij");
-Js.log(Js.String.substrAtMost(~from=12, ~length=2, "abcdefghij") == "");
+Js.String.substrAtMost(~from=3, ~length=4, "abcdefghij") == "defg";
+Js.String.substrAtMost(~from=(-3), ~length=4, "abcdefghij") == "hij";
+Js.String.substrAtMost(~from=12, ~length=2, "abcdefghij") == "";
 ```
 
 ## substring
@@ -667,10 +676,12 @@ let substring: (~from: int, ~to_: int, t) => t;
 - If `finish` is zero or negative, the empty string is returned.
 - If `start` is greater than `finish`, the `start` and `finish` points are swapped.
 
+See [`String.substring`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) on MDN.
+
 ```re example
-Js.log(Js.String.substring(~from=3, ~to_=6, "playground") == "ygr");
-Js.log(Js.String.substring(~from=6, ~to_=3, "playground") == "ygr");
-Js.log(Js.String.substring(~from=4, ~to_=12, "playground") == "ground");
+Js.String.substring(~from=3, ~to_=6, "playground") == "ygr";
+Js.String.substring(~from=6, ~to_=3, "playground") == "ygr";
+Js.String.substring(~from=4, ~to_=12, "playground") == "ground";
 ```
 
 ## substringToEnd
@@ -683,10 +694,12 @@ let substringToEnd: (~from: int, t) => t;
 - If `start` is less than or equal to zero, the entire string is returned.
 - If `start` is greater than or equal to the length of `str`, the empty string is returned.
 
+See [`String.substring`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) on MDN.
+
 ```re example
-Js.log(Js.String.substringToEnd(~from=4, "playground") == "ground");
-Js.log(Js.String.substringToEnd(~from=(-3), "playground") == "playground");
-Js.log(Js.String.substringToEnd(~from=12, "playground") == "");
+Js.String.substringToEnd(~from=4, "playground") == "ground";
+Js.String.substringToEnd(~from=(-3), "playground") == "playground";
+Js.String.substringToEnd(~from=12, "playground") == "";
 ```
 
 ## toLowerCase
@@ -696,12 +709,12 @@ let toLowerCase: t => t;
 ```
 
 `toLowerCase(str)` converts `str` to lower case using the locale-insensitive case mappings in the Unicode Character Database.
-Notice that the conversion can give different results depending upon context, for example with the Greek letter sigma, which has two different lower case forms when it is the last character in a string or not.
+Notice that the conversion can give different results depending upon context, for example with the Greek letter sigma, which has two different lower case forms; one when it is the last character in a string and one when it is not. See [`String.toLowerCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase) on MDN.
 
 ```re example
-Js.log(Js.String.toLowerCase("ABC") == "abc");
-Js.log(Js.String.toLowerCase({js|ΣΠ|js}) == {js|σπ|js});
-Js.log(Js.String.toLowerCase({js|ΠΣ|js}) == {js|πς|js});
+Js.String.toLowerCase("ABC") == "abc";
+Js.String.toLowerCase({js|ΣΠ|js}) == {js|σπ|js};
+Js.String.toLowerCase({js|ΠΣ|js}) == {js|πς|js};
 ```
 
 ## toLocaleLowerCase
@@ -710,7 +723,7 @@ Js.log(Js.String.toLowerCase({js|ΠΣ|js}) == {js|πς|js});
 let toLocaleLowerCase: t => t;
 ```
 
-`toLocaleLowerCase(str)` converts `str` to lower case using the current locale.
+`toLocaleLowerCase(str)` converts `str` to lower case using the current locale. See [`String.toLocaleLowerCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase) on MDN.
 
 ## toUpperCase
 
@@ -719,12 +732,12 @@ let toUpperCase: t => t;
 ```
 
 `toUpperCase(str)` converts `str` to upper case using the locale-insensitive case mappings in the Unicode Character Database. 
-Notice that the conversion can expand the number of letters in the result; for example the German ß capitalizes to two Ses in a row.
+Notice that the conversion can expand the number of letters in the result; for example the German ß capitalizes to two Ses in a row. See [`String.toUpperCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toUpperCase) on MDN.
 
 ```re example
-Js.log(Js.String.toUpperCase("abc") == "ABC");
-Js.log(Js.String.toUpperCase({js|Straße|js}) == {js|STRASSE|js});
-Js.log(Js.String.toUpperCase({js|πς|js}) == {js|ΠΣ|js});
+Js.String.toUpperCase("abc") == "ABC";
+Js.String.toUpperCase({js|Straße|js}) == {js|STRASSE|js};
+Js.String.toUpperCase({js|πς|js}) == {js|ΠΣ|js};
 ```
 
 ## toLocaleUpperCase
@@ -733,7 +746,7 @@ Js.log(Js.String.toUpperCase({js|πς|js}) == {js|ΠΣ|js});
 let toLocaleUpperCase: t => t;
 ```
 
-`toLocaleUpperCase(str)` converts `str` to upper case using the current locale.
+`toLocaleUpperCase(str)` converts `str` to upper case using the current locale. See [`String.to:LocaleUpperCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase) on MDN.
 
 ## trim
 
@@ -741,11 +754,11 @@ let toLocaleUpperCase: t => t;
 let trim: t => t;
 ```
 
-`trim(str)` returns a string that is `str` with whitespace stripped from both ends. Internal whitespace is not removed.
+`trim(str)` returns a string that is `str` with whitespace stripped from both ends. Internal whitespace is not removed. See [`String.trim`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim) on MDN.
 
 ```re example
-Js.log(Js.String.trim("   abc def   ") == "abc def");
-Js.log(Js.String.trim("\n\r\t abc def \n\n\t\r ") == "abc def");
+Js.String.trim("   abc def   ") == "abc def";
+Js.String.trim("\n\r\t abc def \n\n\t\r ") == "abc def";
 ```
 
 ## anchor
@@ -754,10 +767,10 @@ Js.log(Js.String.trim("\n\r\t abc def \n\n\t\r ") == "abc def");
 let anchor: (t, t) => t;
 ```
 
-`anchor(anchorName, anchorText)` creates a string with an HTML `<a>` element with name attribute of `anchorName` and `anchorText` as its content.
+`anchor(anchorName, anchorText)` creates a string with an HTML `<a>` element with name attribute of `anchorName` and `anchorText` as its content. Please do not use this method, as it has been removed from the relevant web standards. See [`String.anchor`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/anchor) on MDN.
 
 ```re example
-Js.log(Js.String.anchor("page1", "Page One")); /* prints "<a name=\"page1\">Page One</a>" */
+Js.String.anchor("page1", "Page One") == "<a name=\"page1\">Page One</a>"
 ```
 
 ## link
@@ -766,10 +779,10 @@ Js.log(Js.String.anchor("page1", "Page One")); /* prints "<a name=\"page1\">Page
 let link: (t, t) => t;
 ```
 
-ES2015: `link(urlText, linkText)` creates a string with an HTML `<a>` element with href attribute of `urlText` and `linkText` as its content.
+ES2015: `link(urlText, linkText)` creates a string with an HTML `<a>` element with href attribute of `urlText` and `linkText` as its content. Please do not use this method, as it has been removed from the relevant web standards. See [`String.link`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/link) on MDN.
 
 ```re example
-Js.log(Js.String.link("page2.html", "Go to page two")); /* prints "<a href=\"page2.html\">Go to page two</a>" */
+Js.String.link("page2.html", "Go to page two") == "<a href=\"page2.html\">Go to page two</a>";
 ```
 
 ## castToArrayLike
@@ -778,4 +791,10 @@ Js.log(Js.String.link("page2.html", "Go to page two")); /* prints "<a href=\"pag
 let castToArrayLike: t => Js_array2.array_like(t);
 ```
 
-ES2015
+Casts its argument to an `array_like` entity that can be processed by functions such as `Js.Array2.fromMap()`
+
+```re example
+let s = "abcde";
+let arr = Js.Array2.fromMap(Js.String.castToArrayLike(s), (x)=>{x});
+arr == [|"a", "b", "c", "d", "e"|];
+```


### PR DESCRIPTION
* Added links to MDN for corresponding methods.
* Added deprecation notes for `array()` and `link()`
* Added legacy function note for `substr()`.
* Eliminated `Js.log()` in examples.