### PR TITLE
Add meta link to RSS feed

### DIFF
--- a/components/Meta.re
+++ b/components/Meta.re
@@ -92,5 +92,11 @@ let make =
       content="summary_large_image"
     />
     <meta key="twitter:image" property="twitter:image" content=ogImage />
+    <link
+      rel="alternate"
+      type_="application/rss+xml"
+      title="ReasonML Blog"
+      href="/blog/feed.xml"
+    />
   </Head>;
 };


### PR DESCRIPTION
This makes it easier for RSS readers to find the RSS feed so that people
that want to subscribe can just add reasonml.org to their RSS reader.