### PR TITLE
Fix small typo for new list syntax

### DIFF
--- a/pages/docs/reason-compiler/latest/new-bucklescript-syntax.mdx
+++ b/pages/docs/reason-compiler/latest/new-bucklescript-syntax.mdx
@@ -25,7 +25,7 @@ This document gives an overview over the most relevant features until more detai
 - Interpolated string: from `{j|hello ${name}|j}` to `` j`hello ${name}` ``.
 - Polymorphic variants: from `` `red`` to `#red`.
 - Arrays: from `[|1,2,3|]` to `[1,2,3]`. In JS, arrays are the right default.
-- Lists: from `[1,2,3]` to `list[1,2,3]`. This ties with upcoming plans to access containers in a uniform way: `set[...]` and `map[...]`. Maybe temporary.
+- Lists: from `[1,2,3]` to `list{1,2,3}`. This ties with upcoming plans to access containers in a uniform way: `set{...}` and `map{...}`. Maybe temporary.
 - Exception: from `try (compute()) { | Not_found => Js.log("oops")}` to `try compute() catch { | Not_found => Js.log("oops")}`.
 - First class module: from `(module S: Student)` to `module(S: Student)`.
 - No custom infix operator for now (including `mod`).


### PR DESCRIPTION
I may be missing some context as to why it's written this way but experimentally it seems like the syntax is `list{1, 2, 3}` and not `list[1, 2,3]`.