### PR TITLE
Update links to genType examples

### DIFF
--- a/pages/docs/gentype/latest/getting-started.mdx
+++ b/pages/docs/gentype/latest/getting-started.mdx
@@ -134,9 +134,9 @@ support, and only `namespace:true` is possible, not e.g. `namespace:"custom"`.
 We prepared some examples to give you an idea on how to integrate `genType` in
 your own project. Check out the READMEs of the listed projects.
 
-- [flow-react-example](https://github.com/cristianoc/genType/tree/master/examples/flow-react-example)
-- [typescript-react-example](https://github.com/cristianoc/genType/tree/master/examples/typescript-react-example)
-- [untyped-react-example](https://github.com/cristianoc/tree/blob/master/examples/untyped-react-example)
+- [flow-react-example](https://github.com/reason-association/genType/tree/master/examples/flow-react-example)
+- [typescript-react-example](https://github.com/reason-association/genType/tree/master/examples/typescript-react-example)
+- [untyped-react-example](https://github.com/reason-association/genType/tree/master/examples/untyped-react-example)
 
 ## Experimental features
 


### PR DESCRIPTION
The link to the `untyped-react-example` was broken. I ended up updating the links to all of the examples since genType has been moved under the Reason Association organization.